### PR TITLE
Attempt to Fix incorrect site matches.

### DIFF
--- a/Contents/Code/PAsearchSites.py
+++ b/Contents/Code/PAsearchSites.py
@@ -618,6 +618,12 @@ def getSearchSiteIDByFilter(searchFilter):
         #  Blacked -> BlackedRaw
         #  Babes -> FootsieBabes
         #  PassionHD Love Ties -> HD Love
+        try:
+            if searchFilter.lower().replace(".com","").replace("'","").split(' ', 1)[0] == sites[0].lower().replace(" ","").replace("'",""):
+                return searchID
+        except:
+            pass
+        
         if sites[0].lower().replace(" ","").replace("'","") in searchFilter.lower().replace(".com","").replace("'","") or sites[0].lower().replace(" ","").replace("'","") in searchFilter.lower().replace(".com","").replace(" ","").replace("'",""):
             return searchID
         searchID += 1


### PR DESCRIPTION
Fixes things like Stepsiblingscaught always matching to stepsiblings.

Fixes examples like PassionHD - Love and Lemonade matching to HD Love

Only works if your filename has the Site without spaces. i.e PassionHD not Passion HD.

No impact to existing code though. Just tries this method first.