### PR TITLE
Handle NewSensations case where search by name fails

### DIFF
--- a/Contents/Code/siteNewSensations.py
+++ b/Contents/Code/siteNewSensations.py
@@ -10,8 +10,12 @@ def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor
             searchString = searchTitle.replace(" ","-")
             searchResults = HTML.ElementFromURL(PAsearchSites.getSearchBaseURL(searchSiteID) + "/tour_ns/models/" + searchString + ".html")
         except:
-            searchString = searchTitle.replace(" ","")
-            searchResults = HTML.ElementFromURL(PAsearchSites.getSearchBaseURL(searchSiteID) + "/tour_ns/models/" + searchString + ".html")
+            try:
+                searchString = searchTitle.replace(" ","")
+                searchResults = HTML.ElementFromURL(PAsearchSites.getSearchBaseURL(searchSiteID) + "/tour_ns/models/" + searchString + ".html")
+            except:
+                searchString = searchTitle.replace(" ","")
+                searchResults = HTML.ElementFromURL(PAsearchSites.getSearchBaseURL(searchSiteID) + "/tour_ns/sets.php?id=" + searchString)
         for searchResult in searchResults.xpath('//div[contains(@class,"videoBlock")]'):
             titleNoFormatting = searchResult.xpath('.//div[contains(@class,"caption")]//h4//a')[0].text_content()
             Log("titleNoFormatting: " + titleNoFormatting)

--- a/Contents/Code/siteNewSensations.py
+++ b/Contents/Code/siteNewSensations.py
@@ -15,6 +15,7 @@ def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor
                 searchResults = HTML.ElementFromURL(PAsearchSites.getSearchBaseURL(searchSiteID) + "/tour_ns/models/" + searchString + ".html")
             except:
                 searchString = searchTitle.replace(" ","")
+                searchInt = int(searchString)
                 searchResults = HTML.ElementFromURL(PAsearchSites.getSearchBaseURL(searchSiteID) + "/tour_ns/sets.php?id=" + searchString)
         for searchResult in searchResults.xpath('//div[contains(@class,"videoBlock")]'):
             titleNoFormatting = searchResult.xpath('.//div[contains(@class,"caption")]//h4//a')[0].text_content()


### PR DESCRIPTION
- Some models don't appear under /tour_ns/models/first-last or
  /tour_ns/models/firstlast.
- For example Anya Olsen and Eliza Jane. Anya shows up at
  /tour_ns/sets.php?id=2810 and Eliza at /tour_ns/sets.php?id=2811
- Allow search by id, which isn't ideal but otherwise the models
  aren't findable with the other code.