### PR TITLE
Workaround to manually add actors + some new sites

### DIFF
--- a/Contents/Code/PAactors.py
+++ b/Contents/Code/PAactors.py
@@ -81,6 +81,8 @@ class PhoenixActors:
                 newActor = "Bunny Colby"
             if "April ONeil" == newActor or "April Oneil" == newActor or "April O'neil" == newActor:
                 newActor == "April O'Neil"
+            if "Maddy OReilly" == newActor or "Maddy Oreilly" == newActor or "Maddy O'reilly" == newActor:
+                newActor == "Maddy O'Reilly"
             if "Tiny Teen" == newActor or "Tieny Mieny" == newActor or "Lady Jay" == newActor:
                 newActor == "Eva Elfie"
             if "Rebel Lynn (Contract Star)" == newActor:

--- a/Contents/Code/PAsearchSites.py
+++ b/Contents/Code/PAsearchSites.py
@@ -53,7 +53,7 @@ import siteTrenchcoatX
 import siteDorcelClub
 import siteMissaX
 import siteMylf
-import manualActors
+import addActors
 
 searchSites = [None] * 685
 searchSites[1] = ["Blacked com","Blacked","https://www.blacked.com","https://www.blacked.com/search?q="]

--- a/Contents/Code/PAsearchSites.py
+++ b/Contents/Code/PAsearchSites.py
@@ -811,6 +811,7 @@ def getSearchSettings(mediaTitle):
     mediaTitle = re.sub('^nb ', 'NaughtyBookworms ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^naughtyamericavr ', 'NaughtyAmerica ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^naf ', 'NeighborAffair ', mediaTitle, flags=re.IGNORECASE)
+    mediaTitle = re.sub('^na ', 'NaughtyAthletics ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^mwhf ', 'MyWifesHotFriend ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^mts ', 'MomsTeachSex ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^mrs ', 'MassageRooms ', mediaTitle, flags=re.IGNORECASE)

--- a/Contents/Code/PAsearchSites.py
+++ b/Contents/Code/PAsearchSites.py
@@ -51,8 +51,10 @@ import networkTMW
 import siteScrewbox
 import siteTrenchcoatX
 import siteMissaX
+import siteMylf
 
-searchSites = [None] * 671
+
+searchSites = [None] * 681
 searchSites[1] = ["Blacked com","Blacked","https://www.blacked.com","https://www.blacked.com/search?q="]
 searchSites[0] = ["Blackedraw com","BlackedRaw","https://www.blackedraw.com","https://www.blackedraw.com/search?q="]
 searchSites[2] = ["Brazzers.com","Brazzers","http://www.brazzers.com","http://www.brazzers.com/search/all/?q="]
@@ -724,6 +726,16 @@ searchSites[667] = ["TrenchcoatX","TrenchcoatX","https://trenchcoatx.com","https
 searchSites[668] = ["Screwbox","Screwbox","https://screwbox.com","https://screwbox.com/search.php?query="]
 searchSites[669] = ["MissaX","MissaX","https://missax.com","https://missax.com/tour/search.php?query="]
 searchSites[670] = ["AllHerLuv","AllHerLuv","https://allherluv.com","https://allherluv.com/tour/search.php?query="]
+searchSites[671] = ["Mylf","Mylf","https://mylf.com","https://www.mylf.com/movies/"]
+searchSites[672] = ["MylfBoss","MylfBoss","https://mylf.com","https://www.mylf.com/movies/"]
+searchSites[673] = ["MylfBlows","MylfBlows","https://mylf.com","https://www.mylf.com/movies/"]
+searchSites[674] = ["Mylfty","Mylfty","https://mylf.com","https://www.mylf.com/movies/"]
+searchSites[675] = ["GotMylf","GotMylf","https://mylf.com","https://www.mylf.com/movies/"]
+searchSites[676] = ["MomDrips","MomDrips","https://mylf.com","https://www.mylf.com/movies/"]
+searchSites[677] = ["Mylfed","Mylfed","https://mylf.com","https://www.mylf.com/movies/"]
+searchSites[678] = ["MylfBody","MylfBody","https://mylf.com","https://www.mylf.com/movies/"]
+searchSites[679] = ["LoneMylf","LoneMylf","https://mylf.com","https://www.mylf.com/movies/"]
+searchSites[680] = ["FullOfJOI","FullOfJOI","https://mylf.com","https://www.mylf.com/movies/"]
 
 
 def getSearchBaseURL(siteID):

--- a/Contents/Code/PAsearchSites.py
+++ b/Contents/Code/PAsearchSites.py
@@ -50,8 +50,9 @@ import siteKarups
 import networkTMW
 import siteScrewbox
 import siteTrenchcoatX
+import siteMissaX
 
-searchSites = [None] * 669
+searchSites = [None] * 671
 searchSites[1] = ["Blacked com","Blacked","https://www.blacked.com","https://www.blacked.com/search?q="]
 searchSites[0] = ["Blackedraw com","BlackedRaw","https://www.blackedraw.com","https://www.blackedraw.com/search?q="]
 searchSites[2] = ["Brazzers.com","Brazzers","http://www.brazzers.com","http://www.brazzers.com/search/all/?q="]
@@ -721,6 +722,8 @@ searchSites[665] = ["X Angels","X Angels","http://teenmegaworld.net","http://tee
 searchSites[666] = ["Teen Sex Movs","Teen Sex Movs","http://teenmegaworld.net","http://teenmegaworld.net/search.php?query="]
 searchSites[667] = ["TrenchcoatX","TrenchcoatX","https://trenchcoatx.com","https://trenchcoatx.com/search.php?query="]
 searchSites[668] = ["Screwbox","Screwbox","https://screwbox.com","https://screwbox.com/search.php?query="]
+searchSites[669] = ["MissaX","MissaX","https://missax.com","https://missax.com/tour/search.php?query="]
+searchSites[670] = ["AllHerLuv","AllHerLuv","https://allherluv.com","https://allherluv.com/tour/search.php?query="]
 
 
 def getSearchBaseURL(siteID):

--- a/Contents/Code/PAsearchSites.py
+++ b/Contents/Code/PAsearchSites.py
@@ -53,8 +53,9 @@ import siteTrenchcoatX
 import siteDorcelClub
 import siteMissaX
 import siteMylf
+import manualActors
 
-searchSites = [None] * 684
+searchSites = [None] * 685
 searchSites[1] = ["Blacked com","Blacked","https://www.blacked.com","https://www.blacked.com/search?q="]
 searchSites[0] = ["Blackedraw com","BlackedRaw","https://www.blackedraw.com","https://www.blackedraw.com/search?q="]
 searchSites[2] = ["Brazzers.com","Brazzers","http://www.brazzers.com","http://www.brazzers.com/search/all/?q="]
@@ -739,6 +740,7 @@ searchSites[680] = ["Mylfed","Mylfed","https://mylf.com","https://www.mylf.com/m
 searchSites[681] = ["Milf Body","Milf Body","https://mylf.com","https://www.mylf.com/movies/"]
 searchSites[682] = ["Lone Milf","Lone Milf","https://mylf.com","https://www.mylf.com/movies/"]
 searchSites[683] = ["Full Of JOI","Full Of JOI","https://mylf.com","https://www.mylf.com/movies/"]
+searchSites[684] = ["ManualAddActors","ManualAddActors","",""]
 
 def getSearchBaseURL(siteID):
     return searchSites[siteID][2]
@@ -894,6 +896,7 @@ def getSearchSettings(mediaTitle):
     mediaTitle = re.sub('^bblib ', 'BigButtsLikeItBig ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^baebz ', 'Baeb ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^am ', 'AssMasterpiece ', mediaTitle, flags=re.IGNORECASE)
+    mediaTitle = re.sub('^add ', 'ManualAddActors ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^ad ', 'AmericanDaydreams ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^agm ', 'AllGirlMassage ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^aa ', 'AmateurAllure ', mediaTitle, flags=re.IGNORECASE)

--- a/Contents/Code/PAsearchSites.py
+++ b/Contents/Code/PAsearchSites.py
@@ -729,13 +729,13 @@ searchSites[670] = ["AllHerLuv","AllHerLuv","https://allherluv.com","https://all
 searchSites[671] = ["Mylf","Mylf","https://mylf.com","https://www.mylf.com/movies/"]
 searchSites[672] = ["MylfBoss","MylfBoss","https://mylf.com","https://www.mylf.com/movies/"]
 searchSites[673] = ["MylfBlows","MylfBlows","https://mylf.com","https://www.mylf.com/movies/"]
-searchSites[674] = ["Mylfty","Mylfty","https://mylf.com","https://www.mylf.com/movies/"]
-searchSites[675] = ["GotMylf","GotMylf","https://mylf.com","https://www.mylf.com/movies/"]
-searchSites[676] = ["MomDrips","MomDrips","https://mylf.com","https://www.mylf.com/movies/"]
+searchSites[674] = ["Milfty","Milfty","https://mylf.com","https://www.mylf.com/movies/"]
+searchSites[675] = ["Got Mylf","Got Mylf","https://mylf.com","https://www.mylf.com/movies/"]
+searchSites[676] = ["Mom Drips","Mom Drips","https://mylf.com","https://www.mylf.com/movies/"]
 searchSites[677] = ["Mylfed","Mylfed","https://mylf.com","https://www.mylf.com/movies/"]
-searchSites[678] = ["MylfBody","MylfBody","https://mylf.com","https://www.mylf.com/movies/"]
-searchSites[679] = ["LoneMylf","LoneMylf","https://mylf.com","https://www.mylf.com/movies/"]
-searchSites[680] = ["FullOfJOI","FullOfJOI","https://mylf.com","https://www.mylf.com/movies/"]
+searchSites[678] = ["Milf Body","Milf Body","https://mylf.com","https://www.mylf.com/movies/"]
+searchSites[679] = ["Lone Milf","Lone Milf","https://mylf.com","https://www.mylf.com/movies/"]
+searchSites[680] = ["Full Of JOI","Full Of JOI","https://mylf.com","https://www.mylf.com/movies/"]
 
 
 def getSearchBaseURL(siteID):

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -760,6 +760,13 @@ class PhoenixAdultAgent(Agent.Movies):
                 if searchSiteID == 9999 or (searchSiteID >= 674 and searchSiteID <= 683):
                     results = PAsearchSites.siteMylf.search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor,searchDate, searchSiteID)
 
+            ###############
+            ## Manually Add Actors
+            ###############
+            if siteNum == 684:
+                if searchSiteID == 684:
+                    results = PAsearchSites.addActors.search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor,searchDate, searchSiteID)
+
             siteNum += 1
 
         results.Sort('score', descending=True)
@@ -1271,6 +1278,14 @@ class PhoenixAdultAgent(Agent.Movies):
         ##############################################################
         if (siteID >= 674 and siteID <= 683):
             metadata = PAsearchSites.siteMylf.update(metadata,siteID,movieGenres,movieActors)
+
+        ##############################################################
+        ##                                                          ##
+        ##  Manually Add Actors                                     ##
+        ##                                                          ##
+        ##############################################################
+        if siteID == 684:
+            metadata = PAsearchSites.addActors.update(metadata,siteID,movieGenres,movieActors)
 
 
         ##############################################################

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -732,6 +732,13 @@ class PhoenixAdultAgent(Agent.Movies):
                 if searchSiteID == 9999 or searchSiteID == 669 or searchSiteID == 670:
                     results = PAsearchSites.siteMissaX.search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor,searchDate, searchSiteID)
 
+            ###############
+            ## Mylf
+            ###############
+            if siteNum == 671:
+                if searchSiteID == 9999 or (searchSiteID >= 671 and searchSiteID <= 680):
+                    results = PAsearchSites.siteMylf.search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor,searchDate, searchSiteID)
+
             siteNum += 1
 
         results.Sort('score', descending=True)
@@ -1211,6 +1218,14 @@ class PhoenixAdultAgent(Agent.Movies):
         ##############################################################
         if siteID == 669 or siteID == 670:
             metadata = PAsearchSites.siteMissaX.update(metadata,siteID,movieGenres,movieActors)
+
+        ##############################################################
+        ##                                                          ##
+        ##  Mylf                                                    ##
+        ##                                                          ##
+        ##############################################################
+        if siteID == 671 or siteID == 680:
+            metadata = PAsearchSites.siteMylf.update(metadata,siteID,movieGenres,movieActors)
 
 
         ##############################################################

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1224,7 +1224,7 @@ class PhoenixAdultAgent(Agent.Movies):
         ##  Mylf                                                    ##
         ##                                                          ##
         ##############################################################
-        if siteID == 671 or siteID == 680:
+        if (siteID >= 671 and siteID <= 680):
             metadata = PAsearchSites.siteMylf.update(metadata,siteID,movieGenres,movieActors)
 
 

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -725,6 +725,13 @@ class PhoenixAdultAgent(Agent.Movies):
                 if searchSiteID == 9999 or searchSiteID == 668:
                     results = PAsearchSites.siteScrewbox.search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor,searchDate, searchSiteID)
 
+            ###############
+            ## MissaX / AllHerLuv
+            ###############
+            if siteNum == 669:
+                if searchSiteID == 9999 or searchSiteID == 669 or searchSiteID == 670:
+                    results = PAsearchSites.siteMissaX.search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor,searchDate, searchSiteID)
+
             siteNum += 1
 
         results.Sort('score', descending=True)
@@ -1183,7 +1190,7 @@ class PhoenixAdultAgent(Agent.Movies):
 
         ##############################################################
         ##                                                          ##
-        ##  TrenchcoatX                                     ##
+        ##  TrenchcoatX                                             ##
         ##                                                          ##
         ##############################################################
         if siteID == 667:
@@ -1191,11 +1198,19 @@ class PhoenixAdultAgent(Agent.Movies):
 
         ##############################################################
         ##                                                          ##
-        ##  Tonights Girlfriend                                     ##
+        ##  Screwbox                                                ##
         ##                                                          ##
         ##############################################################
         if siteID == 668:
             metadata = PAsearchSites.siteScrewbox.update(metadata,siteID,movieGenres,movieActors)
+
+        ##############################################################
+        ##                                                          ##
+        ##  MissaX / AllHerLuv                                      ##
+        ##                                                          ##
+        ##############################################################
+        if siteID == 669 or siteID == 670:
+            metadata = PAsearchSites.siteMissaX.update(metadata,siteID,movieGenres,movieActors)
 
 
         ##############################################################

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1242,6 +1242,7 @@ class PhoenixAdultAgent(Agent.Movies):
             metadata = PAsearchSites.networkStrike3.update(metadata,siteID,movieGenres,movieActors)
 
         ##############################################################
+        ##                                                          ##
         ##  MissaX / AllHerLuv                                      ##
         ##                                                          ##
         ##############################################################

--- a/Contents/Code/addActors.py
+++ b/Contents/Code/addActors.py
@@ -1,0 +1,65 @@
+import PAsearchSites
+import PAgenres
+import PAactors
+
+def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor,searchDate,searchSiteID):
+    if searchSiteID != 9999:
+        siteNum = searchSiteID
+    Log("searchTitle:" + searchTitle)
+    searchTitle = searchTitle.replace(' And ',',').replace(' and ',',').replace(' AND ',',')
+    Log("searchTitle replaced:" + searchTitle)
+    actors = searchTitle.split(",")
+    actorsFormatted = []
+    for actor in actors:
+        actorsFormatted.append(actor.strip().title())
+    curID = '+'.join(actorsFormatted).replace(' ','_')
+    Log("curID: " + curID)
+    if searchDate:
+        releaseDate = parse(searchDate).strftime('%Y-%m-%d')
+        Log("releaseDate found: " + releaseDate)
+    else:
+        releaseDate = 'no_date'
+    score = 100
+    results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum) + "|" + releaseDate, name = curID + "[Add Actor] " + releaseDate, score = score, lang = lang))
+
+    return results
+
+def update(metadata,siteID,movieGenres,movieActors):
+    Log("*******Manual actor input*******")
+
+
+    # Title
+    actorList = str(metadata.id).split("|")[0].replace('_',' ').replace('+',', ')
+    metadata.title = actorList
+    Log('title: ' + actorList)
+
+    # Actors
+    movieActors.clearActors()
+    Log("metadata.id: " + str(metadata.id))
+    actors = actorList.split(',')
+    for actor in actors:
+        actorName = actor.strip().title()
+        actorPhotoURL = ''
+        movieActors.addActor(actorName,actorPhotoURL)
+        Log("added actor: " + actorName)
+
+    # Release Date
+    date = str(metadata.id).split("|")[2]
+    if date != 'no_date':
+        Log("Date Found")
+        date_Object = parse(date)
+        metadata.originally_available_at = date_Object
+        metadata.year = metadata.originally_available_at.year
+
+    # Studio
+
+
+    # Tagline and Collection(s)
+    metadata.collections.clear()
+    marker = "Actors Manually Added"
+    metadata.collections.add(marker)
+    # Genres
+    movieGenres.clearGenres()
+
+
+    return metadata

--- a/Contents/Code/addActors.py
+++ b/Contents/Code/addActors.py
@@ -6,9 +6,20 @@ def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor
     if searchSiteID != 9999:
         siteNum = searchSiteID
     Log("searchTitle:" + searchTitle)
-    searchTitle = searchTitle.replace(' And ',',').replace(' and ',',').replace(' AND ',',')
-    Log("searchTitle replaced:" + searchTitle)
-    actors = searchTitle.split(",")
+    searchTitle = searchTitle.replace(' And ',',').replace(' and ',',').replace(' In ', ' in ').replace(' At ', ' at ')
+    parse_siteName = searchTitle.split(' at ')
+    if len(parse_siteName) > 1:
+        siteName = parse_siteName[1].strip().title()
+        Log("Manual Site Name: " + siteName)
+    else:
+        siteName = ''
+    parse_sceneName = parse_siteName[0].split(' in ')
+    if len(parse_sceneName) > 1:
+        sceneName = parse_sceneName[1].strip().title()
+        Log("Manual Scene Name: " + sceneName)
+    else:
+        sceneName = ''
+    actors = parse_sceneName[0].split(",")
     actorsFormatted = []
     for actor in actors:
         actorsFormatted.append(actor.strip().title())
@@ -16,26 +27,24 @@ def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor
     Log("curID: " + curID)
     if searchDate:
         releaseDate = parse(searchDate).strftime('%Y-%m-%d')
-        Log("releaseDate found: " + releaseDate)
     else:
-        releaseDate = 'no_date'
+        releaseDate = ''
+
     score = 100
-    results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum) + "|" + releaseDate, name = curID + "[Add Actor] " + releaseDate, score = score, lang = lang))
+    metadataID = curID + "|" + str(siteNum) + "|" + releaseDate + "|" + sceneName + "|" + siteName
+    Log("metadata.id to pass: " + metadataID)
+    displayName = curID.replace('+',', ').replace('_',' ')
+    results.Append(MetadataSearchResult(id = metadataID, name = displayName + "[" + siteName + "] " + releaseDate, score = score, lang = lang))
 
     return results
 
 def update(metadata,siteID,movieGenres,movieActors):
     Log("*******Manual actor input*******")
 
-
-    # Title
-    actorList = str(metadata.id).split("|")[0].replace('_',' ').replace('+',', ')
-    metadata.title = actorList
-    Log('title: ' + actorList)
-
     # Actors
     movieActors.clearActors()
     Log("metadata.id: " + str(metadata.id))
+    actorList = str(metadata.id).split("|")[0].replace('_',' ').replace('+',', ')
     actors = actorList.split(',')
     for actor in actors:
         actorName = actor.strip().title()
@@ -45,21 +54,40 @@ def update(metadata,siteID,movieGenres,movieActors):
 
     # Release Date
     date = str(metadata.id).split("|")[2]
-    if date != 'no_date':
+    if len(date) > 0:
         Log("Date Found")
         date_Object = parse(date)
         metadata.originally_available_at = date_Object
         metadata.year = metadata.originally_available_at.year
-
-    # Studio
-
+    else:
+        Log("No Date Found")
 
     # Tagline and Collection(s)
     metadata.collections.clear()
     marker = "Actors Manually Added"
     metadata.collections.add(marker)
-    # Genres
-    movieGenres.clearGenres()
 
+    # Studio
+    siteName = str(metadata.id).split("|")[4].strip().title()
+    if len(siteName) > 0:
+        metadata.studio = siteName
+        metadata.collections.add(siteName)
+        Log("Found Studio/SiteName: " + siteName)
+
+    # Title
+    sceneName = str(metadata.id).split("|")[3].strip().title()
+    if len(sceneName) > 0:
+        metadata.title = sceneName
+        Log("sceneName: " + sceneName)
+    else:
+        if len(siteName) > 0:
+            metadata.title = actorList + " - " + siteName
+            Log('title: ' + metadata.title)
+        else:
+            metadata.title = actorList
+            Log('title/actorList: ' + metadata.title)
+
+    # Genres
+    # movieGenres.clearGenres()
 
     return metadata

--- a/Contents/Code/siteMissaX.py
+++ b/Contents/Code/siteMissaX.py
@@ -1,0 +1,106 @@
+import PAsearchSites
+import PAgenres
+def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor,searchDate,searchSiteID):
+    if searchSiteID != 9999:
+        siteNum = searchSiteID
+    searchResults = HTML.ElementFromURL(PAsearchSites.getSearchSearchURL(siteNum) + encodedTitle)
+    for searchResult in searchResults.xpath('//div[@class="updateItem"] | //div[@class="photo-thumb video-thumb"]'):
+        titleNoFormatting = searchResult.xpath('.//h4//a | .//p[@class="thumb-title"]')[0].text_content().strip()
+        Log("Result Title: " + titleNoFormatting)
+        curID = searchResult.xpath('.//a')[0].get('href').replace('/','_').replace('?','!')
+        Log("curID: " + curID)
+        releaseDate = parse(searchResult.xpath('.//span[@class="update_thumb_date"] | .//span[@class="date"]')[0].text_content().strip()).strftime('%Y-%m-%d')
+        Log("releaseDate: " + releaseDate)
+        actors = searchResult.xpath('.//span[@class="tour_update_models"]//a | .//p[@class="model-name"]//a')
+        numActors = len(actors)
+        Log("# actors: " + str(numActors))
+        firstActor = actors[0].text_content().strip()
+        Log("firstActor: " + firstActor)
+        if searchDate:
+            score = 100 - Util.LevenshteinDistance(searchDate, releaseDate)
+        else:
+            score = 100 - Util.LevenshteinDistance(searchTitle.lower(), titleNoFormatting.lower())
+        results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum), name = firstActor + " + " + str((numActors - 1)) + " in " + titleNoFormatting + " [" + PAsearchSites.getSearchSiteName(siteNum) + "] " + releaseDate, score = score, lang = lang))
+    return results
+def update(metadata,siteID,movieGenres,movieActors):
+    url = str(metadata.id).split("|")[0].replace('_','/').replace('!','?')
+    detailsPageElements = HTML.ElementFromURL(url)
+    urlBase = PAsearchSites.getSearchBaseURL(siteID)
+
+    # Title
+    metadata.title = detailsPageElements.xpath('//span[@class="update_title"] | //p[@class="raiting-section__title"]')[0].text_content().strip()
+    Log("Scene Title: " + metadata.title)
+
+    # Studio/Tagline/Collection
+    metadata.studio = "AllHerLuv/MissaX"
+    siteName = PAsearchSites.getSearchSiteName(siteID)
+    metadata.tagline = siteName
+    metadata.collections.clear()
+    metadata.collections.add(siteName)
+
+    # Summary
+    try:
+        metadata.summary = detailsPageElements.xpath('//span[@class="latest_update_description"] | //p[contains(@class,"text")]')[0].text_content().replace("Includes:","").replace("Synopsis:","").strip()
+    except:
+        Log('No summary found')
+
+    # Date
+    try:
+        date = detailsPageElements.xpath('//span[@class="update_date"]')[0].text_content().strip()
+    except:
+        date = detailsPageElements.xpath('//p[@class="dvd-scenes__data"]')[0].text_content().split('|')[1].replace('Added:','').strip()
+    Log("date: " + date)
+    date_object = parse(date)
+    metadata.originally_available_at = date_object
+    metadata.year = metadata.originally_available_at.year
+
+    # Actors
+    movieActors.clearActors()
+    actors = detailsPageElements.xpath('//div[@class="update_block"]//span[@class="tour_update_models"]//a | //p[@class="dvd-scenes__data"][1]//a')
+    Log("actors #: " + str(len(actors)))
+    if len(actors) > 0:
+        for actorLink in actors:
+            actorName = actorLink.text_content().strip()
+            Log("Actor: " + actorName)
+            actorPageURL = actorLink.get('href')
+            actorPageElements = HTML.ElementFromURL(actorPageURL)
+            actorPhotoURL = urlBase + actorPageElements.xpath('//img[contains(@class,"model_bio_thumb")]')[0].get("src0_1x")
+            Log("ActorPhotoURL: " + actorPhotoURL)
+            movieActors.addActor(actorName,actorPhotoURL)
+
+    # Genres
+    movieGenres.clearGenres()
+    genres = detailsPageElements.xpath('//span[@class="tour_update_tags"]//a | //p[@class="dvd-scenes__data"][2]//a')
+    if len(genres) > 0:
+        for genreLink in genres:
+            genre = genreLink.text_content()
+            movieGenres.addGenre(genre)
+
+    # Posters/Background
+    valid_names = list()
+    metadata.posters.validate_keys(valid_names)
+    metadata.art.validate_keys(valid_names)
+
+    if siteName == "MissaX":
+        urlBase = urlBase + "/tour/"
+        background = urlBase + detailsPageElements.xpath('//img[contains(@class,"update_thumb")]')[0].get("src").replace("0.jpg","8.jpg")
+        metadata.art[background] = Proxy.Preview(HTTP.Request(background, headers={'Referer': 'http://www.google.com'}).content, sort_order = 1)
+        posterNum = 1
+        posters = detailsPageElements.xpath('//a[@class="fancybox"]')
+        for posterCur in posters:
+            posterURL = urlBase + posterCur.get("href")
+            metadata.posters[posterURL] = Proxy.Preview(HTTP.Request(posterURL, headers={'Referer': 'http://www.google.com'}).content, sort_order = posterNum)
+            metadata.art[posterURL] = Proxy.Preview(HTTP.Request(posterURL, headers={'Referer': 'http://www.google.com'}).content, sort_order = (posterNum + 1))
+            Log("poster/BG URL: " + posterURL)
+            posterNum += 1
+        posterURL = background.replace("8.jpg","0-large.jpg")
+        metadata.posters[posterURL] = Proxy.Preview(HTTP.Request(posterURL, headers={'Referer': 'http://www.google.com'}).content, sort_order = posterNum)
+        Log("last posterURL: " + posterURL)
+    else:
+        background = urlBase + detailsPageElements.xpath('//img[contains(@class,"update_thumb")]')[0].get("src0_1x")
+        metadata.posters[background] = Proxy.Preview(HTTP.Request(background, headers={'Referer': 'http://www.google.com'}).content, sort_order = 1)
+        metadata.art[background] = Proxy.Preview(HTTP.Request(background, headers={'Referer': 'http://www.google.com'}).content, sort_order = 1)
+
+
+
+    return metadata

--- a/Contents/Code/siteMylf.py
+++ b/Contents/Code/siteMylf.py
@@ -22,15 +22,17 @@ def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor
     Log("firstActor: " + firstActor)
     subSite = searchResults.xpath('//img[@class="lazy img-fluid"]')[0].get("data-original").split('/')[-1].replace('_logo.png','').title()
     Log("subSite: " + subSite)
-    if searchDate == None:
-        searchDate = ''
+    if searchDate:
+        releaseDate = parse(searchDate).strftime('%Y-%m-%d')
+    else:
+        releaseDate = ''
+
     score = 100
-    results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum) + "|" + searchDate , name = titleNoFormatting + " [Mylf/"+subSite+"] ", score = score, lang = lang))
+    results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum) + "|" + releaseDate , name = titleNoFormatting + " [Mylf/"+subSite+"] ", score = score, lang = lang))
 
     return results
 
 def update(metadata,siteID,movieGenres,movieActors):
-    Log('******UPDATE CALLED*******')
 
     url = str(metadata.id).split("|")[0].replace('_','/').replace('?','!')
     detailsPageElements = HTML.ElementFromURL(url)
@@ -75,8 +77,6 @@ def update(metadata,siteID,movieGenres,movieActors):
             actorPhotoURL = actorPage.xpath('//img[contains(@class,"girlthumb")]')[0].get("data-original")
             movieActors.addActor(actorName,actorPhotoURL)
             Log('actor: ' + actorName + ", " + actorPhotoURL)
-
-
 
     ### Posters and artwork ###
     posterNum = 1

--- a/Contents/Code/siteMylf.py
+++ b/Contents/Code/siteMylf.py
@@ -1,0 +1,95 @@
+import PAsearchSites
+import PAgenres
+import PAactors
+
+def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor,searchDate,searchSiteID):
+    if searchSiteID != 9999:
+        siteNum = searchSiteID
+    searchString = searchTitle
+    searchResults = HTML.ElementFromURL(PAsearchSites.getSearchSearchURL(siteNum) + encodedTitle)
+
+    titleNoFormatting = searchResults.xpath('//div[@class="col-12 col-md-7"]//span[contains(@class,"text-lightgray")]')[0].text_content().strip()
+    Log("titleNoFormatting: " + titleNoFormatting)
+    curID = searchResults.xpath('//link[@rel="canonical"]')[0].get('href').replace('/','_').replace('?','!')
+    Log("curID: " + curID)
+    actors = searchResults.xpath('//div[@class="col-12 col-md-8"]//a//span')
+    Log("# actors: " + str(len(actors)))
+    firstActor = actors[0].text_content()
+    Log("firstActor: " + firstActor)
+    subSite = searchResults.xpath('//img[@class="lazy img-fluid"]')[0].get("data-original").split('/')[-1].replace('_logo.png','').title()
+    Log("subSite: " + subSite)
+
+    score = 100
+    results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum), name = titleNoFormatting + " [Mylf/"+subSite+"] ", score = score, lang = lang))
+
+    return results
+
+def update(metadata,siteID,movieGenres,movieActors):
+    Log('******UPDATE CALLED*******')
+
+    url = str(metadata.id).split("|")[0].replace('_','/').replace('?','!')
+    detailsPageElements = HTML.ElementFromURL(url)
+    # art = []
+    metadata.collections.clear()
+    movieGenres.clearGenres()
+    movieActors.clearActors()
+
+    # Studio
+    metadata.studio = 'Mylf'
+
+    # Title
+    metadata.title = detailsPageElements.xpath('//div[@class="col-12 col-md-7"]//span[contains(@class,"text-lightgray")]')[0].text_content().strip()
+    Log("title: " + metadata.title)
+
+    #Tagline and Collection(s)
+    subSite = detailsPageElements.xpath('//img[@class="lazy img-fluid"]')[0].get("data-original").split('/')[-1].replace('_logo.png','').strip().title()
+    metadata.tagline = subSite
+    metadata.collections.add(subSite)
+    Log("subSite: " + subSite)
+
+    # Genres
+    # genres = detailsPageElements.xpath('//span[@class="update_tags"]/a')
+    # if len(genres) > 0:
+    #     for genreLink in genres:
+    #         genreName = genreLink.text_content().strip().lower()
+    #         movieGenres.addGenre(genreName)
+
+    # Release Date
+    # date = detailsPageElements.xpath('//div[@class="cell update_date"]')[0].text_content().strip()
+    # if len(date) > 0:
+    #     date_object = parse(date)
+    #     metadata.originally_available_at = date_object
+    #     metadata.year = metadata.originally_available_at.year
+
+    # Actors
+    actors = detailsPageElements.xpath('//div[@class="col-12 col-md-8"]//a')
+    if len(actors) > 0:
+        for actor in actors:
+            actorName = actor.xpath('./span').text_content().strip()
+            actorPageURL = actorLink.get("href")
+            actorPage = HTML.ElementFromURL(actorPageURL)
+            actorPhotoURL = PAsearchSites.getSearchBaseURL(siteID) + actorPage.xpath('//img[contains(@class,"girlthumb")]')[0].get("src")
+            movieActors.addActor(actorName,actorPhotoURL)
+            Log('actor: ' + actorName + ", " + actorPhotoURL)
+
+
+
+    ### Posters and artwork ###
+    posterNum = 1
+    posters = detailsPageElements.xpath('//div[contains(@class,"trailer-small-images")]//a')
+    for poster in posters:
+        posterLink = poster.get("href")
+        if posterLink != "/join":
+            posterURL = poster.xpath('.//img')[0].get('data-original')
+            metadata.posters[posterURL] = Proxy.Preview(HTTP.Request(posterURL, headers={'Referer': 'http://www.google.com'}).content, sort_order = posterNum)
+            metadata.art[posterURL] = Proxy.Preview(HTTP.Request(posterURL, headers={'Referer': 'http://www.google.com'}).content, sort_order = posterNum)
+            Log('posterURL: ' + posterURL)
+
+    # Video trailer background image
+    preview = detailsPageElements.xpath('//video[@id="my-video"]')[0].get('poster')
+    metadata.art[preview] = Proxy.Preview(HTTP.Request(background, headers={'Referer': 'http://www.google.com'}).content, sort_order = posterNum)
+    Log('previewIMG: ' + preview)
+
+
+
+    return metadata

--- a/README.md
+++ b/README.md
@@ -254,14 +254,14 @@ Supported Networks
 #### - DDFNetwork - *Title Search/Actress
 #### - Dogfart - *Title Search/Actress
 #### - PerfectGonzo Network *Actor Search
-#### - BaDoinkVR Network *Actor search*, *Title Search* (exact spelling)(e.g. Search for "BadoinkVR **actress name**" to choose from all scenes from actress OR .../**scene_title**-#####/ => Search for "BadoinkVR **Scene Title**" in the agent to match specific scene
-#### - CzechVR *Actor Search* (exact spelling)
-#### - VirtualRealPorn *Title Search* (exact spelling)
-#### - VirtualTaboo *Title Search* (true search, partial name allowed)
+#### - BaDoinkVR Network *Actor search, *Title Search (exact spelling)(e.g. Search for "BadoinkVR **actress name**" to choose from all scenes from actress OR .../**scene_title**-#####/ => Search for "BadoinkVR **Scene Title**" in the agent to match specific scene
+#### - CzechVR *Actor Search (exact spelling)
+#### - VirtualRealPorn *Title Search (exact spelling)
+#### - VirtualTaboo *Title Search (true search, partial name allowed)
 #### - VRBangers *Title Search
-#### - SexBabesVR *No Search available, exact URL match only* (e.g. [https://sexbabesvr.com/virtualreality/scene/id/**225-welcum_sexy_architect**/](https://linkthe.net/?https://sexbabesvr.com/virtualreality/scene/id/225-welcum_sexy_architect/) => Search for "SexBabesVR **225-welcum_sexy_architect**" in the agent to match)
-#### - WankzVR Network *Title Search* *Actor search*
-#### - Wankz Network *Title Search* *Actor search*
+#### - SexBabesVR *No Search available, exact URL match only (e.g. [https://sexbabesvr.com/virtualreality/scene/id/**225-welcum_sexy_architect**/](https://linkthe.net/?https://sexbabesvr.com/virtualreality/scene/id/225-welcum_sexy_architect/) => Search for "SexBabesVR **225-welcum_sexy_architect**" in the agent to match)
+#### - WankzVR Network *Title Search *Actor search
+#### - Wankz Network *Title Search *Actor search
 #### - Joymii *Title Search *Actor search
 #### - PornPros Network *No Search available, exact URL match only
 #### - Other PornPros sites *No Search available, exact URL match only
@@ -280,15 +280,18 @@ Supported Networks
 #### - Manyvids (Manyvids - id)
 #### - Spizoo *Title Search *Actor Search
 #### - DigitalPlayground *Title Search *Actor Search
-#### - NewSensations *Actress Search* *DVD search* (exact spellings)
-#### - FinishesTheJob *Title Search* *Actor Search*
-#### - SexArt *Title Search* *Actor Search*
-#### - TeenMegaWorld Network *Title Search* *Actor Search*
-#### - Karups Network *Actor Search*
-#### - Tonight's Girlfriend *Actor Search*
-#### - FamilyStrokes *url Match* *Unofficial Scene Title match*
-#### - TrenchcoatX *Title Search* *Actor Search*
-#### - Screwbox *Title Search* *Actor Search*
+#### - NewSensations *Actress Search *DVD search (exact spellings)
+#### - FinishesTheJob *Title Search *Actor Search
+#### - SexArt *Title Search *Actor Search
+#### - TeenMegaWorld Network *Title Search *Actor Search
+#### - Karups Network *Actor Search
+#### - Tonight's Girlfriend *Actor Search
+#### - FamilyStrokes *url Match *Unofficial Scene Title match
+#### - TrenchcoatX *Title Search *Actor Search
+#### - Screwbox *Title Search *Actor Search
+#### - AllHerLuv *Title Search *Actor Search
+#### - MissaX *Title Search *Actor Search
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ These usually don't make the most intuitive filenames, so it is often better to 
 Examples:
 - PornPros - **eager-hands** (taken from the URL [https://pornpros.com/video/**eager-hands**](https://linkthe.net/?https://pornpros.com/video/eager-hands) to direct match)
 - MomsTeachSex - **314082** (taken from the URL [https://momsteachsex.com/tube/watch/**314082**](https://linkthe.net/?https://momsteachsex.com/tube/watch/314082) to direct match)
+- Mylfed - **1645 straight until wet** (taken from the URL [https://www.mylf.com/movies/**1645/straight-until-wet**](https://linkthe.net/?https://www.mylf.com/movies/**1645/straight-until-wet**) to direct match)
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Currently the features of this metadata agent are:
 - Function to help clean up extraneous Genres
 - Function to map actresses with aliases on different sites together (e.g. Doris Ivy is Gina Gerson)
 - Function to locate an image for actresses where the original site doesn't provide one
+- Workaround to manually set actors for unsupported sites
 
 File Naming
 -----------
@@ -295,9 +296,10 @@ Supported Networks
 #### - FamilyStrokes *url Match *Unofficial Scene Title match
 #### - TrenchcoatX *Title Search *Actor Search
 #### - Screwbox *Title Search *Actor Search
+#### - Dorcel Club *Title Search
 #### - AllHerLuv *Title Search *Actor Search
 #### - MissaX *Title Search *Actor Search
-#### - Dorcel Club *Title Search
+#### - Mylf Network *URL Match
 
 
 


### PR DESCRIPTION
### Workaround to manually set actors
- since Plex doesn't allow you to edit actors via its interface, created a workaround to manually set them
- mimics a separate site to fit within existing framework
- also sets date, scene name and studio name if you wish to pass them as well 
- to set actors, use fix match and search for:
    - "add - actor name **and** actor name **and** actor name" (**and** can be replaced with a comma) **OR**
    - "add **date** actor name **in** scene name **at** site name"
- created this for unsupported websites so I could at least set the actors easily
### New sites
#### MissaX and AllHerLuv - normal search 
#### Mylf network sites - direct url match - see readme change

