### PR TITLE
Reduce the amount of pages indexed

### DIFF
--- a/Contents/Code/networkGammaEnt.py
+++ b/Contents/Code/networkGammaEnt.py
@@ -152,7 +152,7 @@ def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor
         if networkscenepages:
             # Other pages
             i = 2
-            while i < 90:
+            while i < 3:
                 pagenum = i
                 if siteNum == 380:
                     pagenum = i - 1


### PR DESCRIPTION
The current amount of 90 pages results in too many occurrences. i.e., 1440 in girlways.
Usually happens, if the user searches for a complete enhanced title (Sitename - Actors - Title).

It results in searches that are too long and plex to time-out, returning as "no result." Meanwhile, the plug-in keeps indexing the results for 30 minutes or more.

A more conservative three pages might be enough for most searches returning 48 results. A brief check on most gamma sites has shown me that they are generous in the number of results per page.