### PR TITLE
Wicked Exact Match

### DIFF
--- a/Contents/Code/PAsearchSites.py
+++ b/Contents/Code/PAsearchSites.py
@@ -90,8 +90,9 @@ import siteCumLouder
 import siteZTOD
 import siteClubFilly
 import networkCherryPimps
+import siteWicked
 
-searchSites = [None] * 782
+searchSites = [None] * 783
 searchSites[1] = ["Blacked com","Blacked","https://www.blacked.com","https://www.blacked.com/search?q="]
 searchSites[0] = ["Blackedraw com","BlackedRaw","https://www.blackedraw.com","https://www.blackedraw.com/search?q="]
 searchSites[2] = ["Brazzers.com","Brazzers","http://www.brazzers.com","http://www.brazzers.com/search/all/?q="]
@@ -874,6 +875,7 @@ searchSites[778] = ["Drilled","Drilled.XXX","https://www.pimp.xxx","https://pimp
 searchSites[779] = ["BCM","BCM.XXX","https://www.pimp.xxx","https://pimp.xxx/search.php?query="]
 searchSites[780] = ["Petite","Petite.XXX","https://www.pimp.xxx","https://pimp.xxx/search.php?query="]
 searchSites[781] = ["Family","Family.XXX","https://www.pimp.xxx","https://pimp.xxx/search.php?query="]
+searchSites[782] = ["Wicked","Wicked Pictures","https://www.wicked.com","https://wicked.com/en/movie/"]
 
 def getSearchBaseURL(siteID):
     return searchSites[siteID][2]
@@ -1093,6 +1095,7 @@ def getSearchSettings(mediaTitle):
     mediaTitle = re.sub('^tuf ', 'TheUpperFloor ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^wa ', 'WhippedAss ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^wfbg ', 'WeFuckBlackGirls ', mediaTitle, flags=re.IGNORECASE)
+    mediaTitle = re.sub('^wkp ', 'Wicked ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^wlt ', 'WeLiveTogether ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^woc ', 'WildOnCam ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^wov ', 'WivesOnVacation ', mediaTitle, flags=re.IGNORECASE)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1863,7 +1863,7 @@ class PhoenixAdultAgent(Agent.Movies):
         ##                                                          ##
         ##############################################################
         if siteID == 782:
-            metadata = PAsearchSites.networkCherryPimps.update(metadata, siteID, movieGenres, movieActors)
+            metadata = PAsearchSites.siteWicked.update(metadata, siteID, movieGenres, movieActors)
 
         ##############################################################
         ## Cleanup Genres and Add

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1034,6 +1034,13 @@ class PhoenixAdultAgent(Agent.Movies):
                 if searchSiteID == 9999 or (searchSiteID >= 772 and searchSiteID <= 781):
                     results = PAsearchSites.networkCherryPimps.search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor,searchDate, searchSiteID)
 
+            ###############
+            ## Wicked
+            ###############
+            if siteNum == 782:
+                if searchSiteID == 9999 or searchSiteID == 782:
+                    results = PAsearchSites.siteWicked.search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor,searchDate, searchSiteID)
+
             siteNum += 1
 
         results.Sort('score', descending=True)
@@ -1849,7 +1856,14 @@ class PhoenixAdultAgent(Agent.Movies):
         ##############################################################
         if (siteID >= 772 and siteID <= 781):
             metadata = PAsearchSites.networkCherryPimps.update(metadata, siteID, movieGenres, movieActors)
-            
+
+        ##############################################################
+        ##                                                          ##
+        ##  Wicked                                                  ##
+        ##                                                          ##
+        ##############################################################
+        if siteID == 782:
+            metadata = PAsearchSites.networkCherryPimps.update(metadata, siteID, movieGenres, movieActors)
 
         ##############################################################
         ## Cleanup Genres and Add

--- a/docs/manualsearch.md
+++ b/docs/manualsearch.md
@@ -22,7 +22,7 @@ There are 3 available search/matching methods, as listed below:
 + **Available match methods:**
 *These can be used in conjunction with available search methods and will increase the possibility of locating the correct scene. However, they cannot be used as standalone search terms. At least one of these can be utilized, depending on the site.*
   - **Date**
-  - **SceneID** 
+  - **SceneID**
 
 + **SceneID Match:** SceneID can be entered, before other search terms, to increase the possibility for a match. However, it cannot be entered as a standalone search term.
 + **Date Match:** Date can be entered, before other search terms, to improve search results. However, it cannot be entered as a standalone search term.
@@ -59,7 +59,7 @@ Here are some examples for each type of search:
     - `SiteName` `Jane Doe` `An Interesting Plot`
   - Another minimal search, using the site shorthand:
     - `SN` `An Interesting Plot`
-  
+
 + **Limited Search** examples:
   - A search using both actor and scene title:
     - `SiteName` `Jane Doe` `An Interesting Plot`
@@ -67,7 +67,7 @@ Here are some examples for each type of search:
     - `SiteName` `Jane Doe`
   - A search using site shorthand with the scene title:
     - `SN` `An Interesting Plot`
-    
+
 + **Exact Match** examples:
   - An exact search using site name and ID:
     - `SiteName` `SceneID`
@@ -75,6 +75,8 @@ Here are some examples for each type of search:
     - `SN` `SceneID`
   - A direct url match, using only a suffix:
     - `SiteName` `Direct URL`
-      - `PornPros` `eager-hands` (taken from the URL [https://pornpros.com/video/**eager-hands**](https://pornpros.com/video/eager-hands))
+      - `PornPros` `eager-hands` (taken from the URL [https://pornpros.com/video/**eager-hands**](https://dereferer.me/?https%3A//pornpros.com/video/eager-hands))
     - `SiteName` `YY-MM-DD` `Direct URL`
-      - `Mylf` `2019.01.01` `1809 manicured-milf-masturbation` (taken from the URL [https://www.mylf.com/movies/**1809/manicured-milf-masturbation**](https://www.mylf.com/movies/1809/manicured-milf-masturbation))
+      - `Mylf` `2019.01.01` `1809 manicured-milf-masturbation` (taken from the URL [https://www.mylf.com/movies/**1809/manicured-milf-masturbation**](https://dereferer.me/?https%3A//www.mylf.com/movies/1809/manicured-milf-masturbation))
+      - `Wicked` `2019.10.10` `Stranger-Than-Fiction 77675` (taken from the URL [https://www.wicked.com/en/movie/**Stranger-Than-Fiction/77675**](https://dereferer.me/?https%3A//www.wicked.com/en/movie/Stranger-Than-Fiction/77675))
+      - `Wicked` `2019.10.10` `Stranger Than Fiction Scene 1 167063` (taken from the URL [https://www.wicked.com/en/video/**Stranger-Than-Fiction-Scene-1/167063**](https://dereferer.me/?https%3A//www.wicked.com/en/video/Stranger-Than-Fiction-Scene-1/167063))

--- a/docs/sitelist.md
+++ b/docs/sitelist.md
@@ -806,6 +806,7 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
   - WankzVR
 + #### We Are Hairy | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
 + #### WowGirls | Matching type: *[Limited](./manualsearch.md#limited-search)* - **Date Add**
++ #### Wicked | Matching type: *[Exact](./manualsearch.md#exact-match)* - **Direct URL**
 + #### X-Art | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
 + #### XConfessions | Matching type: *[Limited](./manualsearch.md#limited-search)*
 + #### Xempire | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*


### PR DESCRIPTION
- Exact Match (Direct URL) for Wicked
   - Two options: 
          1.  **DVD Page** (preferred): `Wicked` `2019.10.10` `Stranger-Than-Fiction 77675` (taken from the URL of the full DVD page [https://www.wicked.com/en/movie/**Stranger-Than-Fiction/77675**](https://dereferer.me/?https%3A//www.wicked.com/en/movie/Stranger-Than-Fiction/77675)).
                - _This will return a result list of all scenes in the DVD in addition to an option to match the video file to the Full DVD itself._
          2. **Scene Page**: `Wicked` `2019.10.10` `Stranger Than Fiction Scene 1 167063` (taken from the URL of Scene Page [https://www.wicked.com/en/video/**Stranger-Than-Fiction-Scene-1/167063**](https://dereferer.me/?https%3A//www.wicked.com/en/video/Stranger-Than-Fiction-Scene-1/167063)).
                - _This will return the single scene as a result._
- Anonymized links in manual search document
 