### PR TITLE
Mylf Fixes

### DIFF
--- a/Contents/Code/siteMylf.py
+++ b/Contents/Code/siteMylf.py
@@ -10,34 +10,65 @@ def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor
     if "/" not in searchString:
         searchString = searchString.replace("-","/",1)
         Log("searchString formatted")
-    searchResults = HTML.ElementFromURL(PAsearchSites.getSearchSearchURL(siteNum) + searchString)
-
-    titleNoFormatting = searchResults.xpath('//div[@class="col-12 col-md-8"]//span[contains(@class,"text-lightgray")]')[0].text_content().strip()
-    Log("titleNoFormatting: " + titleNoFormatting)
-    curID = searchResults.xpath('//link[@rel="canonical"]')[0].get('href').replace('/','_').replace('?','!')
-    Log("curID: " + curID)
-    actors = searchResults.xpath('//div[@class="col-12 col-md-8"]//a//span')
-    Log("# actors: " + str(len(actors)))
-    firstActor = actors[0].text_content()
-    Log("firstActor: " + firstActor)
-    if "mylfdom" in curID:
-        subSite = "MylfDom"
-    else:
-        subSite = searchResults.xpath('//img[@class="lazy img-fluid"]')[0].get("data-original").split('/')[-1].replace('_logo.png','').title()
-    Log("subSite: " + subSite)
-    if searchDate:
-        releaseDate = parse(searchDate).strftime('%Y-%m-%d')
-    else:
-        releaseDate = ''
-
-    score = 100
-    results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum) + "|" + releaseDate , name = titleNoFormatting + " [Mylf/"+subSite+"] ", score = score, lang = lang))
+    try:
+        searchResults = HTML.ElementFromURL(PAsearchSites.getSearchSearchURL(siteNum) + searchString)
+        titleNoFormatting = searchResults.xpath('//div[@class="col-12 col-md-8"]//span[contains(@class,"text-lightgray")]')[0].text_content().strip()
+        Log("titleNoFormatting: " + titleNoFormatting)
+        curID = searchResults.xpath('//link[@rel="canonical"]')[0].get('href').replace('/','_').replace('?','!')
+        Log("curID: " + curID)
+        actors = searchResults.xpath('//div[@class="col-12 col-md-8"]//a//span')
+        Log("# actors: " + str(len(actors)))
+        firstActor = actors[0].text_content()
+        Log("firstActor: " + firstActor)
+        if "mylfdom" in curID:
+            subSite = "MylfDom"
+        else:
+            subSite = searchResults.xpath('//img[@class="lazy img-fluid"]')[0].get("data-original").split('/')[-1].replace('_logo.png','').title()
+        Log("subSite: " + subSite)
+        if searchDate:
+            releaseDate = parse(searchDate).strftime('%Y-%m-%d')
+        else:
+            releaseDate = ''
+        score = 100
+        results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum) + "|" + releaseDate, name = titleNoFormatting + " [Mylf/"+subSite+"] ", score = score, lang = lang))
+    except:
+        # Manual Matching for Problematic Scenes
+        if searchTitle == "1693/when it rains, she whores":
+            Log("Manual Search Match")
+            curID = ("https://www.mylf.com/movies/1693/when-it-rains,-she-whores!")
+            curID = curID.replace('/','_').replace('?','!').replace(',','+')
+            Log(str(curID))
+            if searchDate:
+                releaseDate = parse(searchDate).strftime('%Y-%m-%d')
+            else:
+                releaseDate = ''
+            results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum) + "|" + releaseDate, name = "When It Rains, She Whores!" + " [Mylf]", score = 101, lang = lang))
+        if searchTitle == "1713/when her man is away, this milf will play":
+            Log("Manual Search Match")
+            curID = ("https://www.mylf.com/movies/1713/when-her-man-is-away,-this-milf-will-play")
+            curID = curID.replace('/','_').replace('?','!').replace(',','+')
+            Log(str(curID))
+            if searchDate:
+                releaseDate = parse(searchDate).strftime('%Y-%m-%d')
+            else:
+                releaseDate = ''
+            results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum) + "|" + releaseDate, name = "When Her Man Is Away, This MILF Will Play" + " [Mylf]", score = 101, lang = lang))
+        if searchTitle == "2049/cheater, cheater milf dick teaser":
+            Log("Manual Search Match")
+            curID = ("https://www.mylf.com/movies/2049/cheater,-cheater-milf-dick-teaser")
+            curID = curID.replace('/','_').replace('?','!').replace(',','+')
+            Log(str(curID))
+            if searchDate:
+                releaseDate = parse(searchDate).strftime('%Y-%m-%d')
+            else:
+                releaseDate = ''
+            results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum) + "|" + releaseDate, name = "Cheater, Cheater MILF Dick Teaser" + " [Mylf]", score = 101, lang = lang))
 
     return results
 
 def update(metadata,siteID,movieGenres,movieActors):
 
-    url = str(metadata.id).split("|")[0].replace('_','/').replace('?','!')
+    url = str(metadata.id).split("|")[0].replace('_','/').replace('?','!').replace('+',',')
     detailsPageElements = HTML.ElementFromURL(url)
     art = []
     metadata.collections.clear()
@@ -143,21 +174,8 @@ def update(metadata,siteID,movieGenres,movieActors):
     Log("Artwork found: " + str(len(art)))
     for posterUrl in art:
         if not PAsearchSites.posterAlreadyExists(posterUrl,metadata):
-            #Download image file for analysis
-            try:
-                img_file = urllib.urlopen(posterUrl)
-                im = StringIO(img_file.read())
-                resized_image = Image.open(im)
-                width, height = resized_image.size
-                #Add the image proxy items to the collection
-                if width > 1 or height > width:
-                    # Item is a poster
-                    metadata.posters[posterUrl] = Proxy.Preview(HTTP.Request(posterUrl, headers={'Referer': 'http://www.google.com'}).content, sort_order = j)
-                if width > 100 and width > height:
-                    # Item is an art item
-                    metadata.art[posterUrl] = Proxy.Preview(HTTP.Request(posterUrl, headers={'Referer': 'http://www.google.com'}).content, sort_order = j)
-                j = j + 1
-            except:
-                pass
+            metadata.posters[posterUrl] = Proxy.Preview(HTTP.Request(posterUrl, headers={'Referer': 'http://www.google.com'}).content, sort_order = j)
+            metadata.art[posterUrl] = Proxy.Preview(HTTP.Request(posterUrl, headers={'Referer': 'http://www.google.com'}).content, sort_order = j)
+            j = j + 1
 
     return metadata


### PR DESCRIPTION
- Manual Scene Matching (Resolves #278)
- Remove code that downloads and analyzes artwork. Unnecessary (only one image available per scene) and resolves some issues with scraping images.