### PR TITLE
DadCrush Overhaul | LetsDoeIt Overhaul | Transsensual Support |…

### DIFF
--- a/Contents/Code/PAsearchSites.py
+++ b/Contents/Code/PAsearchSites.py
@@ -104,8 +104,9 @@ import siteFamilySinners
 import siteReidMyLips
 import sitePlayboyPlus
 import siteMeanaWolf
+import siteTranssensual
 
-searchSites = [None] * 806
+searchSites = [None] * 807
 searchSites[0] = ["Blackedraw com","BlackedRaw","https://www.blackedraw.com","https://www.blackedraw.com/search?q="]
 searchSites[1] = ["Blacked com","Blacked","https://www.blacked.com","https://www.blacked.com/search?q="]
 searchSites[2] = ["Brazzers.com","Brazzers","http://www.brazzers.com","http://www.brazzers.com/search/all/?q="]
@@ -434,7 +435,7 @@ searchSites[324] = ["CumDisgrace","CumDisgrace","https://www.pornpros.com","http
 searchSites[325] = ["CockCompetition","CockCompetition","https://www.pornpros.com","https://pornpros.com/video/"]
 searchSites[326] = ["PimpParade","PimpParade","https://www.pornpros.com","https://pornpros.com/video/"]
 searchSites[327] = ["SquirtDisgrace","SquirtDisgrace","https://www.pornpros.com","https://pornpros.com/video/"]
-searchSites[328] = ["DigitalPlayground","DigitalPlayground","https://www.digitalplayground.com","https://www.digitalplayground.com"]
+searchSites[328] = ["DigitalPlayground","DigitalPlayground","https://www.digitalplayground.com","https://www.digitalplayground.com/scene/"]
 searchSites[329] = ["Throated","Throated","https://www.blowpass.com","https://www.blowpass.com/en/search/throated/scene/"]
 
 searchSites[331] = ["Nuru Massage","Nuru Massage","https://www.fantasymassage.com","https://www.fantasymassage.com/en/search/"]
@@ -912,6 +913,7 @@ searchSites[802] = ["Family Sinners","Family Sinners","https://www.familysinners
 searchSites[803] = ["ReidMyLips","ReidMyLips","https://www.reidmylips.com","https://www.reidmylips.com/"]
 searchSites[804] = ["Playboy Plus","Playboy Plus","https://www.playboyplus.com","https://www.playboyplus.com/search?query="]
 searchSites[805] = ["Meana Wolf","Meana Wolf","https://meanawolf.elxcomplete.com","https://meanawolf.elxcomplete.com/search.php?query="]
+searchSites[806] = ["Transsensual","Transsensual","https://www.transsensual.com/","https://www.transsensual.com/scene/"]
 
 def getSearchBaseURL(siteID):
     return searchSites[siteID][2]
@@ -1001,7 +1003,6 @@ def getSearchSettings(mediaTitle):
     mediaTitle = re.sub('^dc ', 'DorcelVision ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^ddfb ', 'DDFBusty ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^ddfvr ', 'DDFNetworkVR ', mediaTitle, flags=re.IGNORECASE)
-    mediaTitle = re.sub('^Digital Playground ', 'DigitalPlayground ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^dm ', 'DirtyMasseur ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^dnj ', 'DaneJones ', mediaTitle, flags=re.IGNORECASE)
     mediaTitle = re.sub('^dpg ', 'DigitalPlayground ', mediaTitle, flags=re.IGNORECASE)

--- a/Contents/Code/PAsearchSites.py
+++ b/Contents/Code/PAsearchSites.py
@@ -539,7 +539,7 @@ searchSites[428] = ["BarbCummings","BarbCummings","https://www.dogfartnetwork.co
 searchSites[429] = ["TheMinion","TheMinion","https://www.dogfartnetwork.com","https://www.dogfartnetwork.com/tour/search.php?search="]
 searchSites[430] = ["BlacksOnBoys","BlacksOnBoys","https://www.dogfartnetwork.com","https://www.dogfartnetwork.com/tour/search.php?search="]
 searchSites[431] = ["GloryholesAndHandjobs","GloryholesAndHandjobs","https://www.dogfartnetwork.com","https://www.dogfartnetwork.com/tour/search.php?search="]
-searchSites[432] = ["Jules Jordan","Jules Jordan", "https://www.julesjordan.com","https://www.julesjordan.com/trial/search.php?query="]
+searchSites[432] = ["Jules Jordan","Jules Jordan", "https://www.julesjordan.com","http://www.julesjordan.com/trial/search.php?st=advanced&qall="]
 searchSites[433] = ["DDFNetwork","DDFNetwork", "https://ddfnetwork.com","https://ddfnetwork.com/videos/freeword/"]
 searchSites[434] = ["Hands on Hardcore","Hands on Hardcore", "https://ddfnetwork.com","https://ddfnetwork.com/videos/freeword/"]
 searchSites[435] = ["DDF Busty","DDF Busty", "https://ddfnetwork.com","https://ddfnetwork.com/videos/freeword/"]

--- a/Contents/Code/PAsearchSites.py
+++ b/Contents/Code/PAsearchSites.py
@@ -854,7 +854,7 @@ searchSites[744] = ["VIPissy","VIPissy","https://www.vipissy.com","https://www.v
 searchSites[745] = ["GirlsOutWest","GirlsOutWest","https://tour.girlsoutwest.com","https://tour.girlsoutwest.com/trailers/"]
 searchSites[746] = ["Girls Rimming","Girls Rimming","https://www.girlsrimming.com","https://www.girlsrimming.com/tour/trailers/"]
 searchSites[747] = ["Gangbang Creampie","Gangbang Creampie","https://gangbangcreampie.com","https://gangbangcreampie.com/tour/search.php?query="]
-searchSites[748] = ["DadCrush","DadCrush","https://www.dadcrush.com","https://www.dadcrush.com/"]
+searchSites[748] = ["DadCrush","DadCrush","https://www.dadcrush.com","https://www.dadcrush.com/movies/"]
 searchSites[749] = ["Show My BF","Show My BF","https://tour.naughtyamerica.com","https://tour.naughtyamerica.com/search?term="]
 searchSites[750] = ["POV Massage","POV Massage","http://www.fantasymassage.com","http://www.fantasymassage.com/en/search/"]
 searchSites[751] = ["Step Secrets","Step Secrets","http://www.stepsecrets.com","https://stepsecrets.com/?query="]

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1116,6 +1116,13 @@ class PhoenixAdultAgent(Agent.Movies):
                 if searchSiteID == 9999 or searchSiteID == 805:
                     results = PAsearchSites.siteMeanaWolf.search(results, encodedTitle, title, searchTitle, siteNum, lang, searchByDateActor, searchDate, searchSiteID)
 
+            ###############
+            ## Transsensual
+            ###############
+            if siteNum == 806:
+                if searchSiteID == 9999 or searchSiteID == 806:
+                    results = PAsearchSites.siteTranssensual.search(results, encodedTitle, title, searchTitle, siteNum, lang, searchByDateActor, searchDate, searchSiteID)
+
             siteNum += 1
 
         results.Sort('score', descending=True)
@@ -2043,6 +2050,14 @@ class PhoenixAdultAgent(Agent.Movies):
         ##############################################################
         if siteID == 805:
             metadata = PAsearchSites.siteMeanaWolf.update(metadata, siteID, movieGenres, movieActors)
+
+        ##############################################################
+        ##                                                          ##
+        ##  Transsensual                                            ##
+        ##                                                          ##
+        ##############################################################
+        if siteID == 806:
+            metadata = PAsearchSites.siteTranssensual.update(metadata, siteID, movieGenres, movieActors)
 
         ##############################################################
         ## Cleanup Genres and Add

--- a/Contents/Code/networkCherryPimps.py
+++ b/Contents/Code/networkCherryPimps.py
@@ -8,9 +8,9 @@ def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor
     searchPageNum = 1
     while searchPageNum <= 2:
         searchResults = HTML.ElementFromURL(PAsearchSites.getSearchSearchURL(siteNum) + "%22" + encodedTitle + "%22" + "&page=" + str(searchPageNum))
-        for searchResult in searchResults.xpath('//div[@class="video-thumb "]'):
-            titleNoFormatting = searchResult.xpath('.//p[@class="text-thumb"]//a')[0].text_content().strip()
-            curID = searchResult.xpath('.//a')[0].get('href').replace('/','_').replace('?','!')
+        for searchResult in searchResults.xpath('//div[@class="video-thumb  "]'):
+            titleNoFormatting = searchResult.xpath('.//p[@class="text-thumb"]/a[1]')[0].text_content().strip()
+            curID = searchResult.xpath('.//p[@class="text-thumb"]/a[1]')[0].get('href').replace('/','_').replace('?','!')
             subSite = searchResult.xpath('.//p[@class="text-thumb"]//a[@class="badge"]')[0].text_content().strip()
             releaseDate = parse(searchResult.xpath('.//span[@class="date"]')[0].text_content().split("|")[1].strip()).strftime('%Y-%m-%d')
             actorNames = ""
@@ -24,7 +24,6 @@ def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor
                 score = 100 - Util.LevenshteinDistance(searchDate, releaseDate)
             else:
                 score = 100 - Util.LevenshteinDistance(searchTitle.lower(), titleNoFormatting.lower())
-            Log("Score: " + str(score))
             results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum), name = actorNames + " in " + titleNoFormatting + " [CherryPimps/"+subSite+"] " + releaseDate, score = score, lang = lang))
         searchPageNum += 1
 

--- a/Contents/Code/networkMetArt.py
+++ b/Contents/Code/networkMetArt.py
@@ -113,10 +113,9 @@ def updateSexArt(metadata,siteID,movieGenres,movieActors):
 
     # Genres
     movieGenres.clearGenres()
-    genres = ["Glamcore", "Glam"] # site has no genres listed, but some should be put in manually describing the overall genre of the site?
+    genres = ["Glamorous"]
     for genre in genres:
         movieGenres.addGenre(genre)
-        # Log("Genre: " + genre)
 
     # Posters/Background
     valid_names = list()

--- a/Contents/Code/siteAllureMedia.py
+++ b/Contents/Code/siteAllureMedia.py
@@ -176,10 +176,7 @@ def update(metadata,siteID,movieGenres,movieActors):
 
     # Actors
     movieActors.clearActors()
-    try:
-        actors = detailsPageElements.xpath('//div[@class="backgroundcolor_info"]/span[@class="update_models"]/a')
-    except:
-        pass
+    actors = detailsPageElements.xpath('//div[@class="backgroundcolor_info"]/span[@class="update_models"]/a')
     if len(actors) > 0:
         for actorLink in actors:
             actorName = str(actorLink.text_content().strip())
@@ -188,7 +185,7 @@ def update(metadata,siteID,movieGenres,movieActors):
                 actorPage = HTML.ElementFromURL(actorPageURL)
                 actorPhotoURL = actorPage.xpath('//div[@class="cell_top cell_thumb"]/img').get('src')
                 if 'http' not in actorPhotoURL:
-            	    actorPhotoURL = PAsearchSites.getSearchBaseURL(siteID) + actorPhotoURL
+                    actorPhotoURL = PAsearchSites.getSearchBaseURL(siteID) + actorPhotoURL
             except:
                 actorPhotoURL = ''
             movieActors.addActor(actorName,actorPhotoURL)
@@ -367,6 +364,38 @@ def update(metadata,siteID,movieGenres,movieActors):
         movieActors.addActor(actorName, actorPhotoURL)
     if "Emma Wilson" in metadata.title or "Emma Wilson" in metadata.summary:
         actorName = "Emma Wilson"
+        actorPhotoURL = ''
+        movieActors.addActor(actorName, actorPhotoURL)
+    if "Kenzie Reeves" in metadata.title or "Kenzie Reeves" in metadata.summary:
+        actorName = "Kenzie Reeves"
+        actorPhotoURL = ''
+        movieActors.addActor(actorName, actorPhotoURL)
+    if "Devon Green" in metadata.title or "Devon Green" in metadata.summary:
+        actorName = "Devon Green"
+        actorPhotoURL = ''
+        movieActors.addActor(actorName, actorPhotoURL)
+    if "Jane Wilde" in metadata.title or "Jane Wilde" in metadata.summary:
+        actorName = "Jane Wilde"
+        actorPhotoURL = ''
+        movieActors.addActor(actorName, actorPhotoURL)
+    if "Lena Anderson" in metadata.title or "Lena Anderson" in metadata.summary:
+        actorName = "Lena Anderson"
+        actorPhotoURL = ''
+        movieActors.addActor(actorName, actorPhotoURL)
+    if "Lilly Banks" in metadata.title or "Lilly Banks" in metadata.summary:
+        actorName = "Lilly Banks"
+        actorPhotoURL = ''
+        movieActors.addActor(actorName, actorPhotoURL)
+    if "Linda Lay" in metadata.title or "Linda Lay" in metadata.summary:
+        actorName = "Linda Lay"
+        actorPhotoURL = ''
+        movieActors.addActor(actorName, actorPhotoURL)
+    if "Belle Knox" in metadata.title or "Belle Knox" in metadata.summary:
+        actorName = "Belle Knox"
+        actorPhotoURL = ''
+        movieActors.addActor(actorName, actorPhotoURL)
+    if "Miley May" in metadata.title or "Miley May" in metadata.summary:
+        actorName = "Miley May"
         actorPhotoURL = ''
         movieActors.addActor(actorName, actorPhotoURL)
 

--- a/Contents/Code/siteDadCrush.py
+++ b/Contents/Code/siteDadCrush.py
@@ -5,25 +5,18 @@ import PAactors
 def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor,searchDate,searchSiteID):
     if searchSiteID != 9999:
         siteNum = searchSiteID
-    sceneID = encodedTitle.split('%20', 1)[0]
-    Log("SceneID: " + sceneID)
-    try:
-        sceneTitle = encodedTitle.split('%20', 1)[1].replace('%20',' ')
-    except:
-        sceneTitle = ''
-    url = PAsearchSites.getSearchSearchURL(siteNum) + sceneID + "/1/1"
+    searchString = searchTitle.lower().replace(" ","-")
+    Log("searchString: " + searchString)
+    url = PAsearchSites.getSearchSearchURL(siteNum) + searchString
     searchResult = HTML.ElementFromURL(url)
-    titleNoFormatting = searchResult.xpath('//div[@class="container form-player"]/div[1]/div')[0].text_content().strip()
+    titleNoFormatting = searchResult.xpath('//p[@class="video-title hidden-xs"]')[0].text_content().strip()
     curID = url.replace('/','_').replace('?','!')
     subSite = "DadCrush"
     if searchDate:
         releaseDate = parse(searchDate).strftime('%Y-%m-%d')
     else:
         releaseDate = ''
-    if sceneTitle:
-        score = 100 - Util.LevenshteinDistance(sceneTitle.lower(), titleNoFormatting.lower())
-    else:
-        score = 90
+    score = 100
     results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum) + "|" + releaseDate, name = titleNoFormatting + " [TeamSkeet/"+subSite+"] " + releaseDate, score = score, lang = lang))
 
     return results
@@ -44,10 +37,10 @@ def update(metadata,siteID,movieGenres,movieActors):
     metadata.studio = 'TeamSkeet'
 
     # Title
-    metadata.title = detailsPageElements.xpath('//div[@class="container form-player"]/div[1]/div')[0].text_content().strip()
+    metadata.title = detailsPageElements.xpath('//p[@class="video-title hidden-xs"]')[0].text_content().strip()
 
     # Summary
-    metadata.summary = detailsPageElements.xpath('//div[@class="container form-player"]/div[2]/p')[0].text_content().strip()
+    metadata.summary = detailsPageElements.xpath('//div[@class="scene-story"]/p')[0].text_content().strip()
 
     #Tagline and Collection(s)
     tagline = PAsearchSites.getSearchSiteName(siteID).strip()
@@ -68,79 +61,36 @@ def update(metadata,siteID,movieGenres,movieActors):
 
     # Actors
     # Pull actors from URL
-    actors = []
-    actorList = detailsPageElements.xpath('//link[@rel="canonical"]')[0].get('href')
-    Log('actorList:' + actorList)
-    actorList = actorList.split("/")[-1].replace('-',' ').strip()
-    Log('actorList:' + actorList)
-    if 'and' in actorList:
-        actors = actorList.split('and')
-    else:
-        actors.append(actorList)
+    actors = detailsPageElements.xpath('//p[@class="model-name hidden-xs"]/a')
     if len(actors) > 0:
-        if len(actors) == 3:
-            movieGenres.addGenre("Threesome")
-        if len(actors) == 4:
-            movieGenres.addGenre("Foursome")
-        if len(actors) > 4:
-            movieGenres.addGenre("Orgy")
         for actorLink in actors:
-            actorName = str(actorLink.replace('2','').strip())
-            actorPhotoURL = ''
+            actorName = str(actorLink.text_content().strip())
+            try:
+                actorPageURL = PAsearchSites.getSearchBaseURL(siteID) + actorLink.get("href")
+                actorPage = HTML.ElementFromURL(actorPageURL)
+                actorPhotoURL = actorPage.xpath('//img[@class="img-responsive"]')[0].get("src")
+                if 'http' not in actorPhotoURL:
+                    actorPhotoURL = PAsearchSites.getSearchBaseURL(siteID) + actorPhotoURL
+            except:
+                actorPhotoURL = ""
             movieActors.addActor(actorName,actorPhotoURL)
 
     ### Posters and artwork ###
     
-    # Girls page image
-    girlsPageElements = HTML.ElementFromURL('https://www.dadcrush.com/girls')
-    try:
-        art.append(girlsPageElements.xpath('//a[contains(@href,"'+sceneID+'")]//img')[0].get('data-src'))
-    except:
-        pass
-
     # Video trailer background image
     try:
-        twitterBG = detailsPageElements.xpath('//video[@id="main-movie-player"]')[0].get('poster')
+        twitterBG = detailsPageElements.xpath('//div[@class="embed-responsive embed-responsive-16by9"]/stream')[0].get('poster')
         art.append(twitterBG)
     except:
         pass
-    
-    # Sometimes hi.jpg is just a bigger version of med.jpg, sometimes it's a different image entirely; grabbing both to be safe
-    try:
-        twitterBG = detailsPageElements.xpath('//video[@id="main-movie-player"]')[0].get('poster').replace('med.jpg','hi.jpg')
-        art.append(twitterBG)
-    except:
-        pass
-
-    # Scenes page images
-    scenesPageElements = HTML.ElementFromURL('https://www.dadcrush.com/scenes')
-    posters = scenesPageElements.xpath('//a[@id="'+sceneID+'"]/img[contains(@class,"bio")]')
-    for poster in posters:
-        try:
-            art.append(poster.get('src'))
-        except:
-            pass
-
 
     j = 1
     Log("Artwork found: " + str(len(art)))
     for posterUrl in art:
         if not PAsearchSites.posterAlreadyExists(posterUrl,metadata):            
             #Download image file for analysis
-            try:
-                img_file = urllib.urlopen(posterUrl)
-                im = StringIO(img_file.read())
-                resized_image = Image.open(im)
-                width, height = resized_image.size
-                #Add the image proxy items to the collection
-                if width > 1 or height > width:
-                    # Item is a poster
-                    metadata.posters[posterUrl] = Proxy.Preview(HTTP.Request(posterUrl, headers={'Referer': 'http://www.google.com'}).content, sort_order = j)
-                if width > 100 and width > height:
-                    # Item is an art item
-                    metadata.art[posterUrl] = Proxy.Preview(HTTP.Request(posterUrl, headers={'Referer': 'http://www.google.com'}).content, sort_order = j)
+                metadata.posters[posterUrl] = Proxy.Preview(HTTP.Request(posterUrl, headers={'Referer': 'http://www.google.com'}).content, sort_order = j)
+                metadata.art[posterUrl] = Proxy.Preview(HTTP.Request(posterUrl, headers={'Referer': 'http://www.google.com'}).content, sort_order = j)
                 j = j + 1
-            except:
-                pass
 
     return metadata

--- a/Contents/Code/siteDigitalPlayground.py
+++ b/Contents/Code/siteDigitalPlayground.py
@@ -13,7 +13,7 @@ def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor
         sceneTitle = ''
     Log("Scene Title: " + sceneTitle)
 
-    url = "https://www.digitalplayground.com/scene/" + sceneID + "/1"
+    url = PAsearchSites.getSearchSearchURL(siteNum) + sceneID + "/1"
     searchResult = HTML.ElementFromURL(url)
     titleNoFormatting = searchResult.xpath('//h1[@class="wxt7nk-4 fSsARZ"]')[0].text_content().replace('Trailer for','').replace('Trailer','').strip()
     curID = url.replace('/','_').replace('?','!')
@@ -71,11 +71,6 @@ def update(metadata,siteID,movieGenres,movieActors):
         tagline = PAsearchSites.getSearchSiteName(siteID).strip()
         metadata.tagline = tagline
         metadata.collections.add(tagline)
-
-    # Movie Collection
-    if sceneType == "Movie":
-        movieCollection = metadata.title
-        metadata.collections.add(movieCollection)
 
     # Genres
     genres = detailsPageElements.xpath('//div[@class="tjb798-2 flgKJM"]/span[1]/a')

--- a/Contents/Code/siteMofos.py
+++ b/Contents/Code/siteMofos.py
@@ -14,10 +14,10 @@ def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor
     Log("Scene Title: " + sceneTitle)
     url = PAsearchSites.getSearchSearchURL(siteNum) + sceneID + "/1"
     searchResults = HTML.ElementFromURL(url)
-    for searchResult in searchResults.xpath('//div[@class="wxt7nk-0 bsAFqW"]//div[1]/h1'):
+    for searchResult in searchResults.xpath('//div[@class="wxt7nk-0 JqBNK"]//div[1]/h1'):
         titleNoFormatting = searchResult.xpath('//div[1]/h1')[0].text_content().replace('Trailer','').strip()
         curID = url.replace('/','_').replace('?','!')
-        subSite = searchResult.xpath('//div[@class="sc-11m21lp-2 bKVlBB"]')[0].text_content().strip()
+        subSite = searchResult.xpath('//div[@class="sc-11m21lp-2 bYxGJu"]')[0].text_content().strip()
         if sceneTitle:
             score = 100 - Util.LevenshteinDistance(sceneTitle.lower(), titleNoFormatting.lower())
         else:
@@ -49,7 +49,7 @@ def update(metadata,siteID,movieGenres,movieActors):
         pass
 
     #Tagline and Collection(s)
-    tagline = detailsPageElements.xpath('//div[@class="sc-11m21lp-2 bKVlBB"]')[0].text_content().strip()
+    tagline = detailsPageElements.xpath('//div[@class="sc-11m21lp-2 bYxGJu"]')[0].text_content().strip()
     metadata.tagline = tagline
     metadata.collections.add(tagline)
 

--- a/Contents/Code/siteMylf.py
+++ b/Contents/Code/siteMylf.py
@@ -63,6 +63,16 @@ def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor
             else:
                 releaseDate = ''
             results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum) + "|" + releaseDate, name = "Cheater, Cheater MILF Dick Teaser" + " [Mylf]", score = 101, lang = lang))
+        if searchTitle == "2059/rich milf, wet pussy":
+            Log("Manual Search Match")
+            curID = ("https://www.mylf.com/movies/2059/rich-milf,-wet-pussy")
+            curID = curID.replace('/','_').replace('?','!').replace(',','+')
+            Log(str(curID))
+            if searchDate:
+                releaseDate = parse(searchDate).strftime('%Y-%m-%d')
+            else:
+                releaseDate = ''
+            results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum) + "|" + releaseDate, name = "Rich MILF, Wet Pussy" + " [Mylf]", score = 101, lang = lang))
 
     return results
 

--- a/Contents/Code/sitePorndoePremium.py
+++ b/Contents/Code/sitePorndoePremium.py
@@ -1,81 +1,113 @@
 import PAsearchSites
 import PAgenres
+import PAactors
+
 def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor,searchDate,searchSiteID):
     if searchSiteID != 9999:
         siteNum = searchSiteID
     searchResults = HTML.ElementFromURL(PAsearchSites.getSearchSearchURL(siteNum) + encodedTitle)
     for searchResult in searchResults.xpath('//div[@class="col col-33 t-col-50 m-col-100"]'):
-        #Log(searchResult.text_content())
-        titleNoFormatting = searchResult.xpath('.//a[@class="main-url"]')[0].get('title')
-        subSite = searchResult.xpath('.//a[@class="uppercase"]')[0].get('title')
-        curID = searchResult.xpath('.//a[@class="main-url"]')[0].get('href').replace('/','_').replace('?','!')
-
-        score = 102 - Util.LevenshteinDistance(searchTitle.lower(), titleNoFormatting.lower())
-        titleNoFormatting = titleNoFormatting + " [LetsDoeIt/"+subSite+"]"
-        results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum), name = titleNoFormatting, score = score, lang = lang))
+        titleNoFormatting = searchResult.xpath('.//div[@data-item="c-11 r-11 / bottom"]/a')[0].get('title')
+        subSite = searchResult.xpath('.//div[@data-item="c-21 r-11 / bottom right"]/a')[0].get('title')
+        curID = searchResult.xpath('.//div[@data-item="c-11 r-11 / bottom"]/a')[0].get('href').replace('/','_').replace('?','!')
+        releaseDate = parse(searchResult.xpath('.//div[@data-item="c-21 r-21 / middle right"]/p')[0].text_content().strip()).strftime('%Y-%m-%d')
+        if searchDate:
+            score = 100 - Util.LevenshteinDistance(searchDate, releaseDate)
+        else:
+            score = 100 - Util.LevenshteinDistance(searchTitle.lower(), titleNoFormatting.lower())
+        results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum), name = titleNoFormatting + " [LetsDoeIt/" + subSite + "] " + releaseDate, score = score, lang = lang))
 
     return results
 
 def update(metadata,siteID,movieGenres,movieActors):
     Log('******UPDATE CALLED*******')
-    url = str(metadata.id).split("|")[0].replace('_','/').replace('?','!')
 
+    url = str(metadata.id).split("|")[0].replace('_','/').replace('!','?')
     detailsPageElements = HTML.ElementFromURL(url)
+    art = []
+    metadata.collections.clear()
+    movieGenres.clearGenres()
+    movieActors.clearActors()
 
-    # Summary
+    # Studio
     metadata.studio = "Porndoe Premium"
 
-    metadata.summary = detailsPageElements.xpath('//meta[@itemprop="description"]')[0].get('content')
-    metadata.title = detailsPageElements.xpath('//div[@itemprop="video"]/meta[@itemprop="name"]')[0].get('content')
-    releaseDate = detailsPageElements.xpath('//meta[@itemprop="uploadDate"]')[0].get('content')
-    date_object = parse(releaseDate)
-    metadata.originally_available_at = date_object
-    metadata.year = metadata.originally_available_at.year 
-    metadata.tagline = detailsPageElements.xpath('//h4[@class="h5 no-space"]/a/strong')[0].text_content()
-    metadata.collections.clear()
-    metadata.collections.add(metadata.tagline)
+    # Title
+    metadata.title = detailsPageElements.xpath('//h1[@class="no-space transform-none"]')[0].text_content().strip()
+
+    # Summary
+    metadata.summary = detailsPageElements.xpath('//meta[@name="description"]')[0].get('content')
+
+    # Tagline and Collection(s)
+    tagline = detailsPageElements.xpath('//div[@class="actors"]/h4/a')[0].text_content()
+    metadata.tagline = tagline
+    metadata.collections.add(tagline)
 
     # Genres
-    movieGenres.clearGenres()
-    genres = detailsPageElements.xpath('//a[contains(@href,"/videos/category/")]')
-
+    genres = detailsPageElements.xpath('//a[@class="inline-links"]')
     if len(genres) > 0:
         for genreLink in genres:
-            genreName = genreLink.text_content().strip('\n').lower()
+            genreName = genreLink.text_content().strip().lower()
             movieGenres.addGenre(genreName)
-    
-    genres = detailsPageElements.xpath('//a[contains(@href,"/videos/tag/")]')
 
-    if len(genres) > 0:
-        for genreLink in genres:
-            genreName = genreLink.text_content().strip('\n').lower()
-            movieGenres.addGenre(genreName)
+    # Release Date
+    date = detailsPageElements.xpath('//div[@class="h5 h5-published nowrap color-rgba255-06"]')[0].text_content().strip()
+    if len(date) > 0:
+        date_object = datetime.strptime(date, '%d %B %Y')
+        metadata.originally_available_at = date_object
+        metadata.year = metadata.originally_available_at.year
 
     # Actors
-    movieActors.clearActors()
-    actors = detailsPageElements.xpath('//a[@class="secondary-color links"]')
+    actors = detailsPageElements.xpath('//span[@class="group inline"]/a')
     if len(actors) > 0:
         for actorLink in actors:
-            actorName = actorLink.text_content()
             actorPageURL = actorLink.get("href")
             actorPage = HTML.ElementFromURL(actorPageURL)
-            actorPhotoURL = actorPage.xpath('//div[@class="avatar"]/picture/img[@class="lazy"]')[0].get("data-src")
-            movieActors.addActor(actorName,actorPhotoURL)
+            actorName = actorPage.xpath('//div[@data-item="c-13 r-11 m-c-15 / middle"]/h1')[0].text_content().strip()
+            try:
+                actorPhotoURL = actorPage.xpath('//div[@class="avatar"]/picture[2]/img')[0].get("data-src")
+                if 'http' not in actorPhotoURL:
+                    actorPhotoURL = PAsearchSites.getSearchBaseURL(siteID) + actorPhotoURL
+            except:
+                actorPhotoURL = ""
+            movieActors.addActor(actorName, actorPhotoURL)
 
-    # Posters/Background
+    ### Posters and artwork ###
+
+    # Video trailer background image
     try:
-        background = detailsPageElements.xpath('//picture[@class="poster"]/img')[0].get("src").replace("/1472x828/", "/1920x1080/")
-        metadata.art[background] = Proxy.Preview(HTTP.Request(background).content, sort_order = 1)
+        twitterBG = detailsPageElements.xpath('//picture[@class="poster"]//img')[0].get('src')
+        art.append(twitterBG)
     except:
         pass
-    
-    posters = detailsPageElements.xpath('//img[@class="swiper-lazy"]')
-    posterNum = 1
-    for poster in posters:
-        posterURL = poster.get("data-src").replace("/0x250/","/1920x1080/")
-        metadata.posters[posterURL] = Proxy.Preview(HTTP.Request(posterURL).content, sort_order = posterNum)
-        metadata.art[posterURL] = Proxy.Preview(HTTP.Request(posterURL).content, sort_order = posterNum + 1)
-        posterNum += 1
+
+    # Photos
+    photos = detailsPageElements.xpath('//div[@id="gallery-thumbs"]//img')
+    if len(photos) > 0:
+        for photoLink in photos:
+            photo = photoLink.get('src')
+            art.append(photo)
+
+    j = 1
+    Log("Artwork found: " + str(len(art)))
+    for posterUrl in art:
+        if not PAsearchSites.posterAlreadyExists(posterUrl,metadata):
+            #Download image file for analysis
+            try:
+                img_file = urllib.urlopen(posterUrl)
+                im = StringIO(img_file.read())
+                resized_image = Image.open(im)
+                width, height = resized_image.size
+                #Add the image proxy items to the collection
+                if width > 1 or height > width:
+                    # Item is a poster
+                    metadata.posters[posterUrl] = Proxy.Preview(HTTP.Request(posterUrl, headers={'Referer': 'http://www.google.com'}).content, sort_order = j)
+                if width > 100 and width > height:
+                    # Item is an art item
+                    metadata.art[posterUrl] = Proxy.Preview(HTTP.Request(posterUrl, headers={'Referer': 'http://www.google.com'}).content, sort_order = j)
+                j = j + 1
+            except:
+                pass
     
 
 

--- a/Contents/Code/siteTranssensual.py
+++ b/Contents/Code/siteTranssensual.py
@@ -1,0 +1,116 @@
+import PAsearchSites
+import PAgenres
+import PAactors
+
+def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchByDateActor,searchDate,searchSiteID):
+    if searchSiteID != 9999:
+        siteNum = searchSiteID
+    sceneID = encodedTitle.split('%20', 1)[0]
+    Log("SceneID: " + sceneID)
+    try:
+        sceneTitle = encodedTitle.split('%20', 1)[1].replace('%20',' ')
+    except:
+        sceneTitle = ''
+    Log("Scene Title: " + sceneTitle)
+
+    url = PAsearchSites.getSearchSearchURL(siteNum) + sceneID + "/1"
+    searchResult = HTML.ElementFromURL(url)
+    titleNoFormatting = searchResult.xpath('//h1[@class="wxt7nk-4 fSsARZ"]')[0].text_content().replace('Trailer','').strip()
+    curID = url.replace('/','_').replace('?','!')
+    if sceneTitle:
+        score = 100 - Util.LevenshteinDistance(sceneTitle.lower(), titleNoFormatting.lower())
+    else:
+        score = 90
+    results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum), name = titleNoFormatting + " [Transsensual] ", score = score, lang = lang))
+    return results
+
+
+def update(metadata,siteID,movieGenres,movieActors):
+    Log('******UPDATE CALLED*******')
+
+    url = str(metadata.id).split("|")[0].replace('_','/').replace('?','!')
+    detailsPageElements = HTML.ElementFromURL(url)
+    art = []
+    metadata.collections.clear()
+    movieGenres.clearGenres()
+    movieActors.clearActors()
+
+    # Studio
+    metadata.studio = 'Mile High Media'
+
+    # Title
+    metadata.title = detailsPageElements.xpath('//h1[@class="wxt7nk-4 fSsARZ"]')[0].text_content().replace('Trailer','').strip()
+
+    # Summary
+    try:
+        metadata.summary = detailsPageElements.xpath('//div[@class="tjb798-2 flgKJM"]/span[2]/div[2]')[0].text_content().strip()
+    except:
+        pass
+
+    #Tagline and Collection(s)
+    tagline = PAsearchSites.getSearchSiteName(siteID).strip()
+    metadata.tagline = tagline
+    metadata.collections.add(tagline)
+
+    # Genres
+    genres = detailsPageElements.xpath('//div[@class="tjb798-2 flgKJM"]/span[1]/a')
+    if len(genres) > 0:
+        for genreLink in genres:
+            genreName = genreLink.text_content().replace(',','').strip().lower()
+            movieGenres.addGenre(genreName)
+
+    # Release Date
+    date = detailsPageElements.xpath('//div[@class="tjb798-2 flgKJM"]/span[last()]')
+    if len(date) > 0:
+        date = date[0].text_content().strip().replace('Release Date:','')
+        date_object = datetime.strptime(date, '%B %d, %Y')
+        metadata.originally_available_at = date_object
+        metadata.year = metadata.originally_available_at.year
+
+    # Actors
+    try:
+        actors = detailsPageElements.xpath('//a[@class="wxt7nk-6 czvZQW"]')
+        if len(actors) > 0:
+            for actorLink in actors:
+                actorName = str(actorLink.text_content().strip())
+                try:
+                    actorPageURL = PAsearchSites.getSearchBaseURL(siteID) + actorLink.get("href")
+                    detailsActorPage = HTML.ElementFromURL(actorPageURL)
+                    actorPhotoURL = detailsActorPage.xpath('//img[@class="sc-1p8qg4p-2 ibyLSN"]')[0].get('src')
+                except:
+                    actorPhotoURL = ''
+                movieActors.addActor(actorName, actorPhotoURL)
+    except:
+        pass
+
+    ### Posters and artwork ###
+
+    # Video trailer background image (Scene)
+    try:
+        twitterBG = detailsPageElements.xpath('//div[@class="tg5e7m-2 evtSOm"]/img')[0].get('src')
+        art.append(twitterBG)
+    except:
+        pass
+
+    j = 1
+    Log("Artwork found: " + str(len(art)))
+    for posterUrl in art:
+        if not PAsearchSites.posterAlreadyExists(posterUrl,metadata):
+            #Download image file for analysis
+            try:
+                img_file = urllib.urlopen(posterUrl)
+                im = StringIO(img_file.read())
+                resized_image = Image.open(im)
+                width, height = resized_image.size
+                #Add the image proxy items to the collection
+                if width > 1 or height > width:
+                    # Item is a poster
+                    metadata.posters[posterUrl] = Proxy.Preview(HTTP.Request(posterUrl, headers={'Referer': 'http://www.google.com'}).content, sort_order = j)
+                if width > 100 and width > height:
+                    # Item is an art item
+                    metadata.art[posterUrl] = Proxy.Preview(HTTP.Request(posterUrl, headers={'Referer': 'http://www.google.com'}).content, sort_order = j)
+                j = j + 1
+            except:
+                pass
+
+    return metadata

--- a/Contents/Code/siteXart.py
+++ b/Contents/Code/siteXart.py
@@ -385,7 +385,7 @@ def update(metadata,siteID,movieGenres,movieActors):
     movieGenres.clearGenres()
     # No Source for Genres, add manual
     movieGenres.addGenre("Artistic")
-    movieGenres.addGenre("Glamcore")
+    movieGenres.addGenre("Glamorous")
 
     # Actors 
     movieActors.clearActors()

--- a/docs/sitelist.md
+++ b/docs/sitelist.md
@@ -567,7 +567,9 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
   - Xchimera
   - XXX Omas
   - XXXShades
-+ #### PornFidelity | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
++ #### PornFidelity Network | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
+  - PornFidelity
+  - TeenFidelity
 + #### PornPros Network | Matching type: *[Exact](./manualsearch.md#exact-match)* - **Direct URL, Date Add**
   - 18YearsOld
   - 40ozBounce
@@ -700,7 +702,7 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
   - BraceFaced
   - CFNM Teens
   - Dyked
-  - Exxxtra small
+  - Exxxtra Small
   - Gingerpatch
   - Her Freshman Year
   - Innocent High
@@ -726,7 +728,6 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
   - Titty Attack
 + #### Other TeamSkeet Sites | Matching type: *[Exact](./manualsearch.md#exact-match)* - **Direct URL, Date Add**
   - DadCrush
-+ #### TeenFidelity | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
 + #### TeenMegaWorld Network | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
   - 18 First Sex
   - ATMovs

--- a/docs/sitelist.md
+++ b/docs/sitelist.md
@@ -328,7 +328,7 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
   - Sexually Broken
   - Topgrl
 + #### Joymii | Matching type: *[Limited](./manualsearch.md#limited-search)*
-+ #### JulesJordan network | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
++ #### JulesJordan network | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*  **Movies Not Supported**
   - GirlGirl
   - JulesJordan
   - ManuelFerrara

--- a/docs/sitelist.md
+++ b/docs/sitelist.md
@@ -29,7 +29,9 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
 + #### AllHerLuv | Matching type: *[Limited](./manualsearch.md#limited-search)*
 + #### Amateur Allure | Matching type: *[Limited](./manualsearch.md#limited-search)*
 + #### ArchAngel | Matching type: *[Limited](./manualsearch.md#limited-search)*
-+ #### Babes Network | Matching type: *[Exact](./manualsearch.md#exact-match)* - **SceneID, Title Search available for some scenes**
++ #### Babes Network
+  ##### Matching type (main): *[Exact](./manualsearch.md#exact-match)* - **SceneID**
+  ##### Matching type (alternate): *[Limited](./manualsearch.md#limited-search)* - **Title only**
   - Babes
   - Babes Unleashed
   - Black is Better
@@ -118,10 +120,12 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
   - MommyBlowsBest
   - OnlyTeenBlowjobs
   - Throated
-+ #### Brazzers Network | Matching type: *[Limited](./manualsearch.md#limited-search)* - **Title only** **SceneID**
++ #### Brazzers Network
+  ##### Matching type (main): *[Limited](./manualsearch.md#limited-search)* - **Title only.**
+  ##### Matching type (alternate): *[Exact](./manualsearch.md#exact-match)* - **SceneID**
   - Asses In Public
   - Baby Got Boobs
-  - Big Butts like it big
+  - Big Butts Like It Big
   - Big Tits at School
   - Big Tits at Work
   - Big Tits in Sports
@@ -160,7 +164,7 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
   - Family.XXX
   - Petite.XXX
 + #### Clips4Sale | Matching type: *[Exact](./manualsearch.md#exact-match)* - **StudioID with Title Search (ie. Clips4Sale - [47321](https://www.clips4sale.com/studio/47321/marks-head-bobbers-and-hand-jobbers) - Roadhead with Alexa Rydell)**
-+ #### ClubFilly | Matching type: *[Exact](./manualsearch.md#exact-match)* - **SceneID** **DVDs not supported**
++ #### ClubFilly | Matching type: *[Exact](./manualsearch.md#exact-match)* - **SceneID, DVDs not supported**
 + #### ClubSeventeen | Matching type: *[Exact](./manualsearch.md#exact-match)* - **Direct URL**
 + #### CumLouder | Matching type: *[Exact](./manualsearch.md#exact-match)* - **Direct URL**
 + #### CzechAV Network | Matching type: *[Limited](./manualsearch.md#limited-search)* - **Title only**
@@ -218,7 +222,7 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
   - Only Blowjob
   - Sandy's Fantasies
   - Sex Video Casting
-+ #### DigitalPlayground | Matching type: *[Exact](./manualsearch.md#exact-match)* - **SceneID** **Scenes from Movies not supported**
++ #### DigitalPlayground | Matching type: *[Exact](./manualsearch.md#exact-match)* - **SceneID**
 + #### Dogfart | Matching type: *[Limited](./manualsearch.md#limited-search)* - **Date Add**
   - BarbCummings
   - BlackMeatWhiteFeet
@@ -265,7 +269,9 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
   - RoccoSiffredi
   - TeraPatrick
 + #### FamilyHookups | Matching type: *[Exact](./manualsearch.md#exact-match)* - **SceneID**
-+ #### FamilyStrokes | Matching type: *[Exact](./manualsearch.md#exact-match)*  - **Direct URL, Title Search available for some scenes**
++ #### FamilyStrokes
+  ##### Matching type (main): *[Exact](./manualsearch.md#exact-match)*  - **Direct URL**
+  ##### Matching type (alternate): *[Limited](./manualsearch.md#limited-search)* - **Title only**
 + #### FantasyMassage  | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
   - AllGirlMassage
   - FantasyMassage
@@ -379,14 +385,15 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
   - MetArtX
   - SexArt
   - Viv Thomas
-+ #### MileHighNetwork | Matching type: *[Exact](./manualsearch.md#exact-match)* - **SceneID** **Movies Not Supported**
++ #### MileHighNetwork | Matching type: *[Exact](./manualsearch.md#exact-match)* - **SceneID, Movies Not Supported**
   - DoghouseDigital
   - RealityJunkies
   - SweetheartVideo
   - SweetSinner
-+ #### Other MileHighNetwork Sites | Matching type: *[Exact](./manualsearch.md#exact-match)* - **SceneID**
++ #### Other MileHighNetwork Sites | Matching type: *[Exact](./manualsearch.md#exact-match)* - **SceneID, Movies Not Supported**
   - BellesaFilms
   - FamilySinners
+  - Transsensual
 + #### MissaX | Matching type: *[Limited](./manualsearch.md#limited-search)*
 + #### Mofos Network | Matching type: *[Exact](./manualsearch.md#exact-match)* - **SceneID**
   - Don't Break Me

--- a/docs/sitelist.md
+++ b/docs/sitelist.md
@@ -201,7 +201,6 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
   - CzechVR
   - CzechVR Casting
   - CzechVR Fetish
-+ #### DadCrush | Matching type: *[Exact](./manualsearch.md#exact-match)* - **SceneID, Date Add**
 + #### DDFNetwork | Matching type: *[Limited](./manualsearch.md#limited-search)*
   - 1By-Day
   - Cherry Jul
@@ -385,7 +384,7 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
   - RealityJunkies
   - SweetheartVideo
   - SweetSinner
-+ #### Other MileHighNetwork sites | Matching type: *[Exact](./manualsearch.md#exact-match)* - **SceneID**
++ #### Other MileHighNetwork Sites | Matching type: *[Exact](./manualsearch.md#exact-match)* - **SceneID**
   - BellesaFilms
   - FamilySinners
 + #### MissaX | Matching type: *[Limited](./manualsearch.md#limited-search)*
@@ -591,7 +590,7 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
   - ShadyPi
   - SquirtDisgrace
   - TeenBFF
-+ #### Other PornPros sites | Matching type: *[Exact](./manualsearch.md#exact-match)* - **Direct URL, Date Add**
++ #### Other PornPros Sites | Matching type: *[Exact](./manualsearch.md#exact-match)* - **Direct URL, Date Add**
   - Baeb
   - CastingCouch-X
   - Cum4K
@@ -725,6 +724,8 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
   - The Real Workout
   - This Girl Sucks
   - Titty Attack
++ #### Other TeamSkeet Sites | Matching type: *[Exact](./manualsearch.md#exact-match)* - **Direct URL, Date Add**
+  - DadCrush
 + #### TeenFidelity | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
 + #### TeenMegaWorld Network | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
   - 18 First Sex


### PR DESCRIPTION
DadCrush:
- Overhauled. Resolves #499.

LetsDoeIt:
- Overhauled. Resolves #483.

DigitalPlayground:
- Scenes from movies now have their own scene pages on the DP website. Updated to reflect this.

Transsensual:
- Now supported, SceneID only.

CherryPimps Network:
- Search bugfix. Resolves #500.

Mylf Network:
- Manual scene add. Resolves #497.

Amateur Allure:
- More manual actress adds.

Jules Jordan:
- Upgrade to Advanced Search - returns better search results and resolves #507. Thanks, @HWatBobby!

Mofos:
- Search bugfix. Resolves #504. Thanks, @HWatBobby!

Other:
- Genre merges.
- Sitelist updates.

Please test/comment!