### PR TITLE
18vr patch

### DIFF
--- a/Contents/Code/networkBadoinkVR.py
+++ b/Contents/Code/networkBadoinkVR.py
@@ -24,7 +24,8 @@ def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchDate):
             score = 100 - Util.LevenshteinDistance(searchTitle.lower(), titleNoFormatting.lower())
         Log("Score: " + str(score))
 
-        results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name="%s in [%s] % " % (girlName, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
+        name = "[%s] %s in %s %s" % (PAsearchSites.getSearchSiteName(siteNum), girlName, titleNoFormatting, releaseDate)
+        results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name=name, score=score, lang=lang))
 
     return results
 


### PR DESCRIPTION
String template `name="%s in [%s] % "` was missing a `s` but I also added the video title.

fixes:
`Plex Media Server/Plug-ins/PhoenixAdult.bundle/Contents/Code/networkBadoinkVR.py", line 27, in search
    results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name="%s in [%s] % " % (girlName, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
ValueError: incomplete format`