### PR TITLE
milfvr patch

### DIFF
--- a/Contents/Code/siteMilfVR.py
+++ b/Contents/Code/siteMilfVR.py
@@ -1,30 +1,25 @@
 import PAsearchSites
 import PAgenres
-
+import PAutils
 
 def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchDate):
-    encodedTitle = searchTitle.replace('%20', '+')
+    encodedTitle = encodedTitle.replace('%20', '+')
     url = PAsearchSites.getSearchSearchURL(siteNum) + encodedTitle
     data = PAutils.HTTPRequest(url, cookies={
         'sst': 'ulang-en'
     })
     searchResults = HTML.ElementFromString(data)
-    for searchResult in searchResults.xpath('//div[@class="vrVideo"]'):
-        titleNoFormatting = searchResult.xpath('.//h3//a')[0].text_content()
-        Log("Result Title: " + titleNoFormatting)
-        curID = searchResult.xpath('.//a')[0].get('href')
-        curID = curID.replace('/','_').replace('?','!')
-        Log("curID: " + curID)
-        # releaseDate = parse(searchResult.xpath('.//div[@class="date"]')[0].text_content().strip()).strftime('%Y-%m-%d')
-        # Log("releaseDate: " + releaseDate.strip())
+    for searchResult in searchResults.xpath('//ul[@class="cards-list"]//li'):
+        titleNoFormatting = searchResult.xpath('.//div[@class="card__footer"]//div[@class="card__h"]/text()')[0]
+        curID = searchResult.xpath('.//a/@href')[0].replace('/', '_').replace('?', '!')
+        releaseDate = parse(searchResult.xpath('.//div[@class="card__date"]')[0].text_content().strip()).strftime('%Y-%m-%d')
 
-        # if searchDate:
-        #     score = 100 - Util.LevenshteinDistance(searchDate, releaseDate)
-        # else:
-        #     score = 100 - Util.LevenshteinDistance(searchTitle.lower(), titleNoFormatting.lower())
-        score = 100 - Util.LevenshteinDistance(searchTitle.lower(), titleNoFormatting.lower())
+        if searchDate:
+            score = 100 - Util.LevenshteinDistance(searchDate, releaseDate)
+        else:
+            score = 100 - Util.LevenshteinDistance(searchTitle.lower(), titleNoFormatting.lower())
 
-        results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum), name = titleNoFormatting + " [" + PAsearchSites.getSearchSiteName(siteNum) + "] ", score = score, lang = lang))
+        results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 
     return results
 


### PR DESCRIPTION
search broken

`CRITICAL (agentkit:1018) - Exception in the search function of agent named 'PhoenixAdult', called with keyword arguments {'year': None, 'id': '17829', 'name': 'Milfvr on the Pole 180x180 3dh'} (most recent call last):
  File "/Applications/Plex Media Server.app/Contents/Resources/Plug-ins-79e214ead/Framework.bundle/Contents/Resources/Versions/2/Python/Framework/api/agentkit.py", line 1011, in _search
    agent.search(*f_args, **f_kwargs)
  File "/////Plex Media Server/Plug-ins/PhoenixAdult.bundle/Contents/Code/__init__.py", line 995, in search
    results = PAsearchSites.siteBAMVisions.search(results, encodedTitle, title, searchTitle, siteNum, lang, searchDate)
  File "/////Plex Media Server/Plug-ins/PhoenixAdult.bundle/Contents/Code/siteMilfVR.py", line 8, in search
    data = PAutils.HTTPRequest(url, cookies={
NameError: global name 'PAutils' is not defined
`