### PR TITLE
Added support for VRConk, RealJamVR, and VRP Films

### DIFF
--- a/Contents/Code/PAsearchSites.py
+++ b/Contents/Code/PAsearchSites.py
@@ -102,8 +102,10 @@ import networkGammaEntOther
 import siteRealityLovers
 import siteHoloGirlsVR
 import siteLethalHardcoreVR
+import siteVRConk
+import siteVRPFilms
 
-searchSites = [None] * 895
+searchSites = [None] * 897
 
 searchSites[0] = ("BlackedRaw", "BlackedRaw", "https://www.blackedraw.com", "https://www.blackedraw.com/api")
 searchSites[1] = ("Blacked", "Blacked", "https://www.blacked.com", "https://www.blacked.com/api")
@@ -999,6 +1001,8 @@ searchSites[891] = ("HoloGirlsVR", "HoloGirlsVR", "https://www.hologirlsvr.com",
 searchSites[892] = ("LethalHardcoreVR", "LethalHardcoreVR", "https://www.lethalhardcorevr.com", "https://www.lethalhardcorevr.com/lethal-hardcore-vr-scenes.html?fq=")
 searchSites[893] = ("Gender X", "Gender X", "https://www.genderx.com", "https://tsmkfa364q-dsn.algolia.net/1/indexes/*/queries")
 searchSites[894] = ("WhoreCraftVR", "WhoreCraftVR", "https://www.lethalhardcorevr.com", "https://www.lethalhardcorevr.com/lethal-hardcore-vr-scenes.html?fq=")
+searchSites[895] = ("VRConk", "VRConk", "https://www.vrconk.com", "https://vrconk.com/virtualreality/scene/id/")
+searchSites[896] = ("VRP Films", "VRP Films", "https://vrpfilms.com/", "https://vrpfilms.com/vrp-movies/")
 
 def getSearchBaseURL(siteID):
     return searchSites[siteID][2]

--- a/Contents/Code/PAsearchSites.py
+++ b/Contents/Code/PAsearchSites.py
@@ -104,8 +104,9 @@ import siteHoloGirlsVR
 import siteLethalHardcoreVR
 import siteVRConk
 import siteVRPFilms
+import siteRealJamVR
 
-searchSites = [None] * 897
+searchSites = [None] * 898
 
 searchSites[0] = ("BlackedRaw", "BlackedRaw", "https://www.blackedraw.com", "https://www.blackedraw.com/api")
 searchSites[1] = ("Blacked", "Blacked", "https://www.blacked.com", "https://www.blacked.com/api")
@@ -1003,6 +1004,7 @@ searchSites[893] = ("Gender X", "Gender X", "https://www.genderx.com", "https://
 searchSites[894] = ("WhoreCraftVR", "WhoreCraftVR", "https://www.lethalhardcorevr.com", "https://www.lethalhardcorevr.com/lethal-hardcore-vr-scenes.html?fq=")
 searchSites[895] = ("VRConk", "VRConk", "https://www.vrconk.com", "https://vrconk.com/virtualreality/scene/id/")
 searchSites[896] = ("VRP Films", "VRP Films", "https://vrpfilms.com/", "https://vrpfilms.com/vrp-movies/")
+searchSites[897] = ("RealJamVR", "RealJamVR", "https://realjamvr.com/", "https://realjamvr.com/virtualreality/scene/id/")
 
 def getSearchBaseURL(siteID):
     return searchSites[siteID][2]

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1119,7 +1119,12 @@ class PhoenixAdultAgent(Agent.Movies):
             ###############
             elif searchSiteID == 896:
                 results = PAsearchSites.siteVRPFilms.search(results, encodedTitle, title, searchTitle, siteNum, lang, searchDate)    
-
+                
+            ###############
+            ## RealJamVR
+            ###############
+            elif searchSiteID == 897:
+                results = PAsearchSites.siteRealJamVR.search(results, encodedTitle, title, searchTitle, siteNum, lang, searchDate)
         results.Sort('score', descending=True)
 
     def update(self, metadata, media, lang):
@@ -2217,12 +2222,19 @@ class PhoenixAdultAgent(Agent.Movies):
 
         ##############################################################
         ##                                                          ##
-        ##  VRP Films                                                  ##
+        ##  VRP Films                                               ##
         ##                                                          ##
         ##############################################################
         elif siteID == 896:
             metadata = PAsearchSites.siteVRPFilms.update(metadata, siteID, movieGenres, movieActors)
-        
+
+        ##############################################################
+        ##                                                          ##
+        ##  RealJamVR                                               ##
+        ##                                                          ##
+        ##############################################################
+        elif siteID == 897:
+            metadata = PAsearchSites.siteVRPFilms.update(metadata, siteID, movieGenres, movieActors)        
         ##############################################################
         ## Cleanup Genres and Add
         Log("Genres")

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1147,19 +1147,19 @@ class PhoenixAdultAgent(Agent.Movies):
             ###############
             ## VRConk
             ###############
-            elif searchSiteID == 895:
+            elif searchSiteID == 902:
                 results = PAsearchSites.siteVRConk.search(results, encodedTitle, title, searchTitle, siteNum, lang, searchDate)
                 
             ###############
             ## VRP Films
             ###############
-            elif searchSiteID == 896:
+            elif searchSiteID == 903:
                 results = PAsearchSites.siteVRPFilms.search(results, encodedTitle, title, searchTitle, siteNum, lang, searchDate)    
                 
             ###############
             ## RealJamVR
             ###############
-            elif searchSiteID == 897:
+            elif searchSiteID == 904:
                 results = PAsearchSites.siteRealJamVR.search(results, encodedTitle, title, searchTitle, siteNum, lang, searchDate)
         results.Sort('score', descending=True)
 
@@ -2301,7 +2301,7 @@ class PhoenixAdultAgent(Agent.Movies):
         ##  VRConk                                                  ##
         ##                                                          ##
         ##############################################################
-        elif siteID == 895:
+        elif siteID == 902:
             metadata = PAsearchSites.siteVRConk.update(metadata, siteID, movieGenres, movieActors)
 
         ##############################################################
@@ -2309,7 +2309,7 @@ class PhoenixAdultAgent(Agent.Movies):
         ##  VRP Films                                               ##
         ##                                                          ##
         ##############################################################
-        elif siteID == 896:
+        elif siteID == 903:
             metadata = PAsearchSites.siteVRPFilms.update(metadata, siteID, movieGenres, movieActors)
 
         ##############################################################
@@ -2317,7 +2317,7 @@ class PhoenixAdultAgent(Agent.Movies):
         ##  RealJamVR                                               ##
         ##                                                          ##
         ##############################################################
-        elif siteID == 897:
+        elif siteID == 904:
             metadata = PAsearchSites.siteVRPFilms.update(metadata, siteID, movieGenres, movieActors)        
         ##############################################################
         ## Cleanup Genres and Add

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1108,6 +1108,18 @@ class PhoenixAdultAgent(Agent.Movies):
             elif searchSiteID == 894:
                 results = PAsearchSites.siteLethalHardcoreVR.search(results, encodedTitle, title, searchTitle, siteNum, lang, searchDate)
 
+            ###############
+            ## VRConk
+            ###############
+            elif searchSiteID == 895:
+                results = PAsearchSites.siteVRConk.search(results, encodedTitle, title, searchTitle, siteNum, lang, searchDate)
+                
+            ###############
+            ## VRP Films
+            ###############
+            elif searchSiteID == 896:
+                results = PAsearchSites.siteVRPFilms.search(results, encodedTitle, title, searchTitle, siteNum, lang, searchDate)    
+
         results.Sort('score', descending=True)
 
     def update(self, metadata, media, lang):
@@ -2195,6 +2207,22 @@ class PhoenixAdultAgent(Agent.Movies):
         elif siteID == 894:
             metadata = PAsearchSites.siteLethalHardcoreVR.update(metadata, siteID, movieGenres, movieActors)
 
+        ##############################################################
+        ##                                                          ##
+        ##  VRConk                                                  ##
+        ##                                                          ##
+        ##############################################################
+        elif siteID == 895:
+            metadata = PAsearchSites.siteVRConk.update(metadata, siteID, movieGenres, movieActors)
+
+        ##############################################################
+        ##                                                          ##
+        ##  VRP Films                                                  ##
+        ##                                                          ##
+        ##############################################################
+        elif siteID == 896:
+            metadata = PAsearchSites.siteVRPFilms.update(metadata, siteID, movieGenres, movieActors)
+        
         ##############################################################
         ## Cleanup Genres and Add
         Log("Genres")

--- a/Contents/Code/siteRealJamVR.py
+++ b/Contents/Code/siteRealJamVR.py
@@ -1,0 +1,90 @@
+import PAsearchSites
+import PAgenres
+import PAactors
+
+
+def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchDate):
+    searchString = searchTitle.replace(" ","_").replace(",","").replace("'","").replace("?","")
+    Log("searchString: " + searchString)
+    url = PAsearchSites.getSearchSearchURL(siteNum) + searchString
+    searchResults = HTML.ElementFromURL(PAsearchSites.getSearchSearchURL(siteNum) + searchString)
+    titleNoFormatting = searchResults.xpath('//div[@class="title"]//a//h1')[0].text_content().strip()
+    Log("titleNoFormatting: " + titleNoFormatting)
+    curID = url.replace('/','+').replace('?','!')
+    Log("curID: " + curID)
+    releaseDate = parse(searchResults.xpath('//div[@class="date"]')[0].text_content().strip()).strftime('%Y-%m-%d')
+    Log("releaseDate: " + releaseDate)
+
+    if searchDate:
+        score = 100 - Util.LevenshteinDistance(searchDate, releaseDate)
+    else:
+        score = 95
+
+    results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum) , name = titleNoFormatting + " [VRConk] " + releaseDate, score = score, lang = lang))
+
+    return results
+
+
+def update(metadata,siteID,movieGenres,movieActors):
+    url = str(metadata.id).split("|")[0].replace('+','/').replace('?','!')
+    detailsPageElements = HTML.ElementFromURL(url)
+    metadata.collections.clear()
+    movieGenres.clearGenres()
+    movieActors.clearActors()
+    urlBase = PAsearchSites.getSearchBaseURL(siteID)
+
+    # Title
+    metadata.title = detailsPageElements.xpath('//div[@class="title"]//a//h1')[0].text_content().strip()
+    Log("title: " + metadata.title)
+
+    #Tagline and Collection(s)
+    siteName = "RealJamVR"
+    metadata.studio = siteName
+    metadata.tagline = siteName
+    metadata.collections.add(siteName)
+    Log("siteName: " + siteName)
+
+    # Summary
+    summary = detailsPageElements.xpath('//div[@class="desc"]')[0].text_content().strip()
+    metadata.summary = " ".join(summary.splitlines())
+    
+    # Release Date
+    date = detailsPageElements.xpath('//div[@class="date"]')[0].text_content().strip()
+    if len(date) > 0:
+        date_object = parse(date)
+        metadata.originally_available_at = date_object
+        metadata.year = metadata.originally_available_at.year
+
+    # Video trailer background image
+    previewBG = detailsPageElements.xpath('//div[@class="splash-screen fullscreen-message is-visible"]')[0].get("style").replace("background-image: url(","").replace(");","")
+    metadata.art[previewBG] = Proxy.Preview(HTTP.Request(previewBG, headers={'Referer': 'http://www.google.com'}).content, sort_order = 1)
+    Log('previewBG: ' + previewBG)
+
+    # Posters
+    posterNum = 1
+    posters = detailsPageElements.xpath('//div[@class="scene-previews-container"]//a')
+    for poster in posters:
+        posterURL = poster.get("href")
+        posterURL = posterURL
+        metadata.posters[posterURL] = Proxy.Preview(HTTP.Request(posterURL, headers={'Referer': 'http://www.google.com'}).content, sort_order = posterNum)
+        posterNum += 1
+        Log('posterURL: ' + posterURL)
+
+    # Actors
+    actors = detailsPageElements.xpath('//div[@class="featuring commed"]//a')
+    if len(actors) > 0:
+        for actorLink in actors:
+            actorName = actorLink.text_content().strip()
+            Log("actor: " + actorName)
+            actorPageURL = actorLink.get("href")
+            actorPage = HTML.ElementFromURL(actorPageURL)
+            actorPhotoURL = actorPage.xpath('//div[contains(@class, "actor-info")]//img')[0]
+            movieActors.addActor(actorName,actorPhotoURL)
+
+    # Genres
+    genres = detailsPageElements.xpath('//div[@class="tags"]//a')
+    for genre in genres:
+        genreName = genre.text_content().strip()
+        movieGenres.addGenre(genreName)
+
+    return metadata

--- a/Contents/Code/siteVRBangers.py
+++ b/Contents/Code/siteVRBangers.py
@@ -65,11 +65,11 @@ def update(metadata,siteID,movieGenres,movieActors):
             Log("actor: " + actorName)
             actorPageURL = actorLink.get("href")
             actorPage = HTML.ElementFromURL(actorPageURL)
-            actorPhotoURL = actorPage.xpath('//div[@class="single-model-featured"]//img')[0].get("src")
+            actorPhotoURL = actorPage.xpath('//div[@class="single-model__featured overflow-hidden position-relative"]//img')[0].get("src")
             movieActors.addActor(actorName,actorPhotoURL)
 
     # Posters/Background
-    for posterLink in detailsPageElements.xpath('//div[contains(@class,"gallery-top")]/a'):
+    for posterLink in detailsPageElements.xpath('//div[contains(@class,"free-gallery")]/a'):
         art.append(posterLink.get('href'))
         Log("poster: " + posterLink.get('href'))
 

--- a/Contents/Code/siteVRBangers.py
+++ b/Contents/Code/siteVRBangers.py
@@ -65,28 +65,22 @@ def update(metadata,siteID,movieGenres,movieActors):
             Log("actor: " + actorName)
             actorPageURL = actorLink.get("href")
             actorPage = HTML.ElementFromURL(actorPageURL)
-            actorPhotoURL = actorPage.xpath('//div[@class="single-model__featured overflow-hidden position-relative"]//img')[0].get("src")
+            actorPhotoURL = actorPage.xpath('//img[contains(@class, "single-model__featured-img")]/@src')[0]
             movieActors.addActor(actorName,actorPhotoURL)
 
     # Posters/Background
-    for posterLink in detailsPageElements.xpath('//div[contains(@class,"free-gallery")]/a'):
-        art.append(posterLink.get('href'))
-        Log("poster: " + posterLink.get('href'))
+    for posterLink in detailsPageElements.xpath('//a[contains(@class, "justified__item")]/@href'):
+        art.append(posterLink)
+        Log("poster: " + posterLink)
 
     ## Banner
     banner = detailsPageElements.xpath('//section[@class="banner"]//img')[0].get("src")
     Log("banner: " + banner)
     art.append(banner)
 
-    ## Preview image
-    # preview = detailsPageElements.xpath('//div[@class="video-content__watch"]//img')[0].get("src")
-    # Log("preview img:" + preview)
-    # metadata.art[preview] = Proxy.Preview(HTTP.Request(preview, headers={'Referer': 'http://www.google.com'}).content, sort_order = 1)
-
-    j = 2
-    Log("Artwork found: " + str(len(art)))
-    for posterUrl in art:
-        if not PAsearchSites.posterAlreadyExists(posterUrl,metadata):
+    Log('Artwork found: %d' % len(art))
+    for idx, posterUrl in enumerate(art, 1):
+        if not PAsearchSites.posterAlreadyExists(posterUrl, metadata):
             #Download image file for analysis
             try:
                 img_file = urllib.urlopen(posterUrl)
@@ -96,11 +90,10 @@ def update(metadata,siteID,movieGenres,movieActors):
                 #Add the image proxy items to the collection
                 if width > 1 or height > width:
                     # Item is a poster
-                    metadata.posters[posterUrl] = Proxy.Preview(HTTP.Request(posterUrl, headers={'Referer': 'http://www.google.com'}).content, sort_order = j)
+                    metadata.posters[posterUrl] = Proxy.Media(HTTP.Request(posterUrl, headers={'Referer': 'http://www.google.com'}).content, sort_order=idx)
                 if width > 100 and width > height:
                     # Item is an art item
-                    metadata.art[posterUrl] = Proxy.Preview(HTTP.Request(posterUrl, headers={'Referer': 'http://www.google.com'}).content, sort_order = j)
-                j = j + 1
+                    metadata.art[posterUrl] = Proxy.Media(HTTP.Request(posterUrl, headers={'Referer': 'http://www.google.com'}).content, sort_order=idx)
             except:
                 pass
 

--- a/Contents/Code/siteVRConk.py
+++ b/Contents/Code/siteVRConk.py
@@ -45,7 +45,8 @@ def update(metadata,siteID,movieGenres,movieActors):
     Log("siteName: " + siteName)
 
     # Summary
-    metadata.summary = detailsPageElements.xpath('(.//*[@class="d-container"])[4]')[0].text_content().strip()
+    summary = detailsPageElements.xpath('(.//*[@class="d-container"])[4]')[0].text_content().strip()
+    metadata.summary = " ".join(summary.splitlines())
     
     # Release Date
     date = detailsPageElements.xpath('//div[@class="stats-container"]//li[3]//span[2]')[0].text_content().strip()

--- a/Contents/Code/siteVRConk.py
+++ b/Contents/Code/siteVRConk.py
@@ -1,0 +1,86 @@
+import PAsearchSites
+import PAgenres
+import PAactors
+
+
+def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchDate):
+    searchString = searchTitle.replace(" ","_").replace(",","").replace("'","").replace("?","")
+    Log("searchString: " + searchString)
+    url = PAsearchSites.getSearchSearchURL(siteNum) + searchString
+    searchResults = HTML.ElementFromURL(PAsearchSites.getSearchSearchURL(siteNum) + searchString)
+    titleNoFormatting = searchResults.xpath('.//*[@class="item-tr-inner-col inner-col"]//h1')[0].text_content().strip()
+    Log("titleNoFormatting: " + titleNoFormatting)
+    curID = url.replace('/','+').replace('?','!')
+    Log("curID: " + curID)
+    releaseDate = parse(searchResults.xpath('(.//*[@class="sub-label"])[14]')[0].text_content().strip()).strftime('%Y-%m-%d')
+    Log("releaseDate: " + releaseDate)
+
+    if searchDate:
+        score = 100 - Util.LevenshteinDistance(searchDate, releaseDate)
+    else:
+        score = 95
+
+    results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum) , name = titleNoFormatting + " [VRConk] " + releaseDate, score = score, lang = lang))
+
+    return results
+
+
+def update(metadata,siteID,movieGenres,movieActors):
+    url = str(metadata.id).split("|")[0].replace('+','/').replace('?','!')
+    detailsPageElements = HTML.ElementFromURL(url)
+    metadata.collections.clear()
+    movieGenres.clearGenres()
+    movieActors.clearActors()
+    urlBase = PAsearchSites.getSearchBaseURL(siteID)
+
+    # Title
+    metadata.title = detailsPageElements.xpath('//div[contains(@class,"video-details")]//h1[1]')[0].text_content().strip()
+    Log("title: " + metadata.title)
+
+    #Tagline and Collection(s)
+    siteName = "VRConk"
+    metadata.studio = siteName
+    metadata.tagline = siteName
+    metadata.collections.add(siteName)
+    Log("siteName: " + siteName)
+
+    # Summary
+    metadata.summary = detailsPageElements.xpath('(.//*[@class="d-container"])[4]')[0].text_content().strip()
+    
+    # Release Date
+    date = detailsPageElements.xpath('//div[@class="stats-container"]//li[3]//span[2]')[0].text_content().strip()
+    if len(date) > 0:
+        date_object = parse(date)
+        metadata.originally_available_at = date_object
+        metadata.year = metadata.originally_available_at.year
+
+    # Video trailer background image
+    previewBG = detailsPageElements.xpath('//div[@class="splash-screen fullscreen-message is-visible"]')[0].get("style").replace("background-image: url(","").replace(");","")
+    metadata.art[previewBG] = Proxy.Preview(HTTP.Request(previewBG, headers={'Referer': 'http://www.google.com'}).content, sort_order = 1)
+    Log('previewBG: ' + previewBG)
+
+    # Posters
+    posterNum = 1
+    posters = detailsPageElements.xpath('//a[@title="Image 1/5"]')
+    for poster in posters:
+        posterURL = poster.get("href")
+        posterURL = posterURL
+        metadata.posters[posterURL] = Proxy.Preview(HTTP.Request(posterURL, headers={'Referer': 'http://www.google.com'}).content, sort_order = posterNum)
+        posterNum += 1
+        Log('posterURL: ' + posterURL)
+
+    # Actors
+    actors = detailsPageElements.xpath('.//*[@class="models-list"]//img')
+    if len(actors) > 0:
+        for actorLink in actors:
+            actorName = actorLink.get("alt")
+            actorPhotoURL = actorLink.get("src")
+            movieActors.addActor(actorName,actorPhotoURL)
+
+    # Genres
+    genres = detailsPageElements.xpath('//a[@class="link12"]')
+    for genre in genres:
+        genreName = genre.text_content().strip()
+        movieGenres.addGenre(genreName)
+
+    return metadata

--- a/Contents/Code/siteVRPFilms.py
+++ b/Contents/Code/siteVRPFilms.py
@@ -1,0 +1,93 @@
+import PAsearchSites
+import PAgenres
+import PAactors
+
+
+def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchDate):
+    searchString = searchTitle.replace(" ","-").replace(",","").replace("'","").replace("?","")
+    Log("searchString: " + searchString)
+    url = PAsearchSites.getSearchSearchURL(siteNum) + searchString
+    searchResults = HTML.ElementFromURL(PAsearchSites.getSearchSearchURL(siteNum) + searchString)
+    titleNoFormatting = searchResults.xpath('//h3[@class="release-title"]//span')[0].text_content().strip()
+    Log("titleNoFormatting: " + titleNoFormatting)
+    curID = url.replace('/','+').replace('?','!')
+    Log("curID: " + curID)
+    
+    script_text = searchResults.xpath('//script[@type="application/ld+json"][1]')[0].text_content()
+    alpha = script_text.find('datePublished')
+    omega = script_text.find('"',alpha+16)
+    script_date = script_text[alpha+16:omega]
+    releaseDate = parse(script_date).strftime('%Y-%m-%d')
+    Log("releaseDate:" + releaseDate)
+    
+    if searchDate:
+        score = 100 - Util.LevenshteinDistance(searchDate, releaseDate)
+    else:
+        score = 95
+
+    results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum) , name = titleNoFormatting + " [VRP Films] " + releaseDate, score = score, lang = lang))
+
+    return results
+
+def update(metadata,siteID,movieGenres,movieActors):
+    url = str(metadata.id).split("|")[0].replace('+','/').replace('?','!')
+    detailsPageElements = HTML.ElementFromURL(url)
+    metadata.collections.clear()
+    movieGenres.clearGenres()
+    movieActors.clearActors()
+    urlBase = PAsearchSites.getSearchBaseURL(siteID)
+
+    # Title
+    metadata.title = detailsPageElements.xpath('//h3[@class="release-title"]//span')[0].text_content().strip()
+    Log("title: " + metadata.title)
+
+    #Tagline and Collection(s)
+    siteName = "VRP Films"
+    metadata.studio = siteName
+    metadata.tagline = siteName
+    metadata.collections.add(siteName)
+    Log("siteName: " + siteName)
+
+    # Summary
+    paragraph = detailsPageElements.xpath('//meta[@property="og:description"]')[0].get('content')
+    metadata.summary = paragraph
+    
+    # Release Date
+    script_text = detailsPageElements.xpath('//script[@type="application/ld+json"][1]')[0].text_content()
+    alpha = script_text.find('datePublished')
+    omega = script_text.find('"',alpha+16)
+    date = script_text[alpha+16:omega]
+    if len(date) > 0:
+        date_object = parse(date)
+        metadata.originally_available_at = date_object
+        metadata.year = metadata.originally_available_at.year
+
+    # Video trailer background image
+    previewBG = detailsPageElements.xpath('//div[@class="hero-img"]')[0].get("style").replace("background-image: url(","").replace(")","")
+    # previewBG = "https:" + previewBG
+    metadata.art[previewBG] = Proxy.Preview(HTTP.Request(previewBG, headers={'Referer': 'http://www.google.com'}).content, sort_order = 1)
+    Log('previewBG: ' + previewBG)
+
+    # Posters
+    posterNum = 1
+    posters = detailsPageElements.xpath('//a[@class="vrp-lightbox"]')
+    for poster in posters:
+        posterURL = poster.get("href")
+        posterURL = posterURL
+        metadata.posters[posterURL] = Proxy.Preview(HTTP.Request(posterURL, headers={'Referer': 'http://www.google.com'}).content, sort_order = posterNum)
+        posterNum += 1
+        Log('posterURL: ' + posterURL)
+
+    # Actors
+    actors = detailsPageElements.xpath('//div[@class="detail"][2]//p')[0].text_content().strip()
+    actorName = actors[10:].strip()
+    actorPhotoURL = ""
+    movieActors.addActor(actorName,actorPhotoURL)
+
+    # Genres
+    genres = detailsPageElements.xpath('//div[@class="movies-description"]//div[3]//p[1]')
+    for genre in genres:
+        genreName = genre.text_content().strip()
+        movieGenres.addGenre(genreName)
+
+    return metadata


### PR DESCRIPTION
Added support for [http://vrconk.com](url) and [http://vrpfilms.com](url)

**VRConk search type: Exact Match - Direct URL (SiteName - Direct URL)**
Supports: Title, Summary, Release Date, Posters, Genres, Artwork, Actors

**RealJamVR search type: Exact Match - Direct URL (SiteName - Direct URL)**
Supports: Title, Summary, Release Date, Posters, Genres, Artwork, Actors

**VRP FIlms search type: Limited - Title Only**
Supports: Title, Summary (Partial), Release Date, Posters, Artwork, Actors
NOTE: Actor support may have issues with movies with more than one actor

Both sites work without error on multiple files, but I'm still learning xpath + python so apologies for any potential glitches, particularly with VRP Films. 