### PR TITLE
Added Support for DefeatedXXX, DefeatedSexFight, XVirtual, SexLikeReal, LustReality

### DIFF
--- a/Contents/Code/PAsearchSites.py
+++ b/Contents/Code/PAsearchSites.py
@@ -102,8 +102,12 @@ import networkGammaEntOther
 import siteRealityLovers
 import siteHoloGirlsVR
 import siteLethalHardcoreVR
+import siteDefeated
+import siteXVirtual
+import siteLustReality
+import siteSLR
 
-searchSites = [None] * 895
+searchSites = [None] * 900
 
 searchSites[0] = ("BlackedRaw", "BlackedRaw", "https://www.blackedraw.com", "https://www.blackedraw.com/api")
 searchSites[1] = ("Blacked", "Blacked", "https://www.blacked.com", "https://www.blacked.com/api")
@@ -999,6 +1003,11 @@ searchSites[891] = ("HoloGirlsVR", "HoloGirlsVR", "https://www.hologirlsvr.com",
 searchSites[892] = ("LethalHardcoreVR", "LethalHardcoreVR", "https://www.lethalhardcorevr.com", "https://www.lethalhardcorevr.com/lethal-hardcore-vr-scenes.html?fq=")
 searchSites[893] = ("Gender X", "Gender X", "https://www.genderx.com", "https://tsmkfa364q-dsn.algolia.net/1/indexes/*/queries")
 searchSites[894] = ("WhoreCraftVR", "WhoreCraftVR", "https://www.lethalhardcorevr.com", "https://www.lethalhardcorevr.com/lethal-hardcore-vr-scenes.html?fq=")
+searchSites[895] = ("DefeatedXXX", "DefeatedXXX", "http://xxx.defeated.xxx", "http://xxx.defeated.xxx/?s=")
+searchSites[896] = ("Defeated Sex Fight", "Defeated Sex Fight", "https://defeatedsexfight.com", "https://defeatedsexfight.com/?s=")
+searchSites[897] = ("XVirtual", "XVirtual", "https://xvirtual.com", "https://xvirtual.com/tour/search/?q=")
+searchSites[898] = ("Lust Reality", "Lust Reality", "https://www.lustreality.com", "https://www.lustreality.com/virtualreality/scene/id/")
+searchSites[899] = ("Sex Like Real", "Sex Like Real", "https://www.sexlikereal.com", "https://www.sexlikereal.com/scenes/")
 
 def getSearchBaseURL(siteID):
     return searchSites[siteID][2]

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -1107,6 +1107,30 @@ class PhoenixAdultAgent(Agent.Movies):
             ###############
             elif searchSiteID == 894:
                 results = PAsearchSites.siteLethalHardcoreVR.search(results, encodedTitle, title, searchTitle, siteNum, lang, searchDate)
+				
+            ###############
+            ## Defeated
+            ###############
+            elif searchSiteID == 895 or searchSiteID == 896:
+                results = PAsearchSites.siteDefeated.search(results, encodedTitle, title, searchTitle, siteNum, lang, searchDate)
+
+            ###############
+            ## XVirtual
+            ###############
+            elif searchSiteID == 897:
+                results = PAsearchSites.siteXVirtual.search(results, encodedTitle, title, searchTitle, siteNum, lang, searchDate)
+
+            ###############
+            ## Lust Reality
+            ###############
+            elif searchSiteID == 898:
+                results = PAsearchSites.siteLustReality.search(results, encodedTitle, title, searchTitle, siteNum, lang, searchDate)
+
+            ###############
+            ## Sex Like Real
+            ###############
+            elif searchSiteID == 899:
+                results = PAsearchSites.siteSLR.search(results, encodedTitle, title, searchTitle, siteNum, lang, searchDate)
 
         results.Sort('score', descending=True)
 
@@ -2194,6 +2218,38 @@ class PhoenixAdultAgent(Agent.Movies):
         ##############################################################
         elif siteID == 894:
             metadata = PAsearchSites.siteLethalHardcoreVR.update(metadata, siteID, movieGenres, movieActors)
+		
+        ##############################################################
+        ##                                                          ##
+        ##  Defeated		                                             ##
+        ##                                                          ##
+        ##############################################################
+        elif siteID == 895 or siteID == 896:
+            metadata = PAsearchSites.siteDefeated.update(metadata, siteID, movieGenres, movieActors)
+
+        ##############################################################
+        ##                                                          ##
+        ##  XVirtual	                                         ##
+        ##                                                          ##
+        ##############################################################
+        elif siteID == 897:
+            metadata = PAsearchSites.siteXVirtual.update(metadata, siteID, movieGenres, movieActors)
+
+        ##############################################################
+        ##                                                          ##
+        ##  Lust Reality	                                         ##
+        ##                                                          ##
+        ##############################################################
+        elif siteID == 898:
+            metadata = PAsearchSites.siteLustReality.update(metadata, siteID, movieGenres, movieActors)
+
+        ##############################################################
+        ##                                                          ##
+        ##  Sex Like Real	                                         ##
+        ##                                                          ##
+        ##############################################################
+        elif siteID == 899:
+            metadata = PAsearchSites.siteSLR.update(metadata, siteID, movieGenres, movieActors)
 
         ##############################################################
         ## Cleanup Genres and Add

--- a/Contents/Code/siteDefeated.py
+++ b/Contents/Code/siteDefeated.py
@@ -1,0 +1,101 @@
+import PAsearchSites
+import PAgenres
+import PAactors
+import PAutils
+
+
+def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchDate):
+    searchString = encodedTitle.replace(" ","+")
+    searchResults = HTML.ElementFromURL(PAsearchSites.getSearchSearchURL(siteNum) + searchString)
+    Log("Results found: " + str(len(searchResults.xpath('//h2[contains(@class,"post-title") and contains(@class,"entry-title")]'))))
+    i = 0
+    for searchResult in searchResults.xpath('//h2[contains(@class,"post-title") and contains(@class,"entry-title")]'):
+        titleNoFormatting = searchResult.xpath('//h2[contains(@class,"post-title") and contains(@class,"entry-title")]')[i].text_content().title().strip()
+        Log ("Title: " +titleNoFormatting)
+        curID = PAutils.Encode(searchResult.xpath('//h2[contains(@class,"post-title") and contains(@class,"entry-title")]/a')[i].get('href'))
+        Log("curID: " +curID)
+        try:
+            releaseDate3 = searchResult.xpath('//meta[@itemprop="datePublished"]')[i].get('content').split("T")
+            releaseDate = releaseDate3[0].strip()
+            Log("releaseDate: " +releaseDate)
+        except:
+            releaseDate = ""
+            Log("No date found (Defeated)")
+        if searchDate:
+            score = 100 - Util.LevenshteinDistance(searchDate, releaseDate)
+        else:
+            score = 100 - Util.LevenshteinDistance(searchTitle.lower(), titleNoFormatting.lower())
+        Log("Score: " + str(score))
+        results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum) + "|" + releaseDate, name = titleNoFormatting + " [" + PAsearchSites.getSearchSiteName(siteNum) + "] " + releaseDate, score = score, lang = lang))
+        i = i +1
+		
+    return results
+
+
+def update(metadata,siteID,movieGenres,movieActors):
+    Log('******UPDATE CALLED*******')
+
+    path = PAutils.Decode(str(metadata.id).split("|")[0])
+    url = PAsearchSites.getSearchBaseURL(siteID) + path
+    detailsPageElements = HTML.ElementFromURL(path)
+    art = []
+    metadata.collections.clear()
+    movieGenres.clearGenres()
+    movieActors.clearActors()
+
+    # Studio/Tagline/Collection
+    metadata.studio = PAsearchSites.getSearchSiteName(siteID)
+    metadata.tagline = metadata.studio
+    metadata.collections.clear()
+    metadata.collections.add(metadata.studio)
+	
+    # TITLE
+    title = detailsPageElements.xpath('//meta[@property="og:title"]')[0].get('content').split("|")
+    titleFixed = title[0].strip()
+    metadata.title = titleFixed
+    Log('Title: ' +  metadata.title)
+
+    # Summary
+    metadata.summary = ((detailsPageElements.xpath('//meta[@property="og:description"]')[0].get('content')) + ("..."))
+    Log('summary: ' +  metadata.summary)
+	
+    # Rating
+    rating = detailsPageElements.xpath('//div[(contains(@class,"gdrts-rating-text"))]/strong')[0].text_content().strip()
+    metadata.rating = ((float(rating))*2)
+    Log('rating: ' +  rating + '*2')
+
+    # Posters/Background
+    valid_names = list()
+    metadata.posters.validate_keys(valid_names)
+    metadata.art.validate_keys(valid_names)
+    posters = detailsPageElements.xpath('//img[(contains(@class,"alignnone") and ((contains(@class,"size-full")) or (contains(@class,"size-medium")))) and not(contains(@class,"wp-image-4512"))]')
+    posters2 = detailsPageElements.xpath('//div[(contains(@class,"iehand"))]/a')
+    posters3 = detailsPageElements.xpath('//a[contains(@class,"colorbox-cats")]')
+    posterNum = 1
+    for posterCur in posters:
+        posterURL = posterCur.get('src')
+        metadata.posters[posterURL] = Proxy.Preview(HTTP.Request(posterURL, headers={'Referer': 'http://www.google.com'}).content, sort_order = posterNum)
+        posterNum = posterNum + 1	
+    for posterCur2 in posters2:
+        posterURL = posterCur2.get('href')
+        metadata.posters[posterURL] = Proxy.Preview(HTTP.Request(posterURL, headers={'Referer': 'http://www.google.com'}).content, sort_order = posterNum)
+        posterNum = posterNum + 1	
+    for posterCur3 in posters3:
+        posterURL = posterCur3.get('href')
+        metadata.posters[posterURL] = Proxy.Preview(HTTP.Request(posterURL, headers={'Referer': 'http://www.google.com'}).content, sort_order = posterNum)
+        posterNum = posterNum + 1		
+    backgroundURL = detailsPageElements.xpath('//meta[@property="og:image"]')[0].get('content').split('?')
+    metadata.art[backgroundURL[0]] = Proxy.Preview(HTTP.Request(backgroundURL[0], headers={'Referer': 'http://www.google.com'}).content, sort_order = 1)
+
+    # Date
+    try:
+        date = detailsPageElements.xpath('//meta[@property="article:published_time"]')[0].get('content').split("T")
+        dateFixed = date[0].strip()
+        Log('DateFixed: ' + dateFixed)
+        date_object = datetime.strptime(dateFixed, '%Y-%m-%d')
+        metadata.originally_available_at = date_object
+        metadata.year = metadata.originally_available_at.year
+    except:
+        Log("No date found")
+
+    return metadata

--- a/Contents/Code/siteLustReality.py
+++ b/Contents/Code/siteLustReality.py
@@ -1,0 +1,80 @@
+import PAsearchSites
+import PAgenres
+
+
+def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchDate):
+    url = PAsearchSites.getSearchSearchURL(siteNum) + searchTitle.lower().replace(" ","-", 1).replace(" ","-")
+    searchResults = HTML.ElementFromURL(url)
+
+    titleNoFormatting = searchResults.xpath('//h1')[0].text_content().strip()
+    curID = searchTitle.lower().replace(" ","-", 1).replace(" ","-")
+    releaseDate = parse(searchResults.xpath('//span[@class="date-display-single"] | //span[@class="u-inline-block u-mr--nine"] | //div[@class="video-meta-date"] | //div[@class="date"]')[0].text_content().strip()).strftime('%b %d, %Y')
+
+    score = 100
+    results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum), name = titleNoFormatting + " ["+ PAsearchSites.getSearchSiteName(siteNum) +"] " + releaseDate, score = score, lang = lang))
+    return results
+
+
+def update(metadata,siteID,movieGenres,movieActors):
+    temp = str(metadata.id).split("|")[0]
+    url = PAsearchSites.getSearchSearchURL(siteID) + temp
+    detailsPageElements = HTML.ElementFromURL(url)
+
+    # Studio
+    metadata.studio = "Lust Reality"
+
+    # Title
+    metadata.title = detailsPageElements.xpath('//h1')[0].text_content().strip()
+
+    # Summary
+    metadata.summary = detailsPageElements.xpath('//div[@class="u-mb--six u-fs--fo u-lh--normal"]')[0].text_content().strip()
+
+    # Date
+    date_object = parse(detailsPageElements.xpath('//span[@class="date-display-single"] | //span[@class="u-inline-block u-mr--nine"] | //div[@class="video-meta-date"] | //div[@class="date"]')[0].text_content().strip())
+    metadata.originally_available_at = date_object
+    metadata.year = metadata.originally_available_at.year
+	
+    # Studio/Tagline/Collection
+    metadata.studio = PAsearchSites.getSearchSiteName(siteID)
+    metadata.tagline = metadata.studio
+    metadata.collections.clear()
+    metadata.collections.add(metadata.studio)
+	
+    # Genres
+    movieGenres.clearGenres()
+    genres = detailsPageElements.xpath('//ul[@class="u-list u-list--inline u-fs--th u-ff--alt"]/li/a')
+    if len(genres) > 0:
+        for genre in genres:
+            movieGenres.addGenre(genre.text_content().lower())
+
+    # Actors
+    movieActors.clearActors()
+    actors = detailsPageElements.xpath('//div[@class="video-actress-name"]//a | //div[@class="u-mt--three u-mb--three"]//a | //div[@class="model-one-inner js-trigger-lazy-item"]//a | //div[@class="featuring commed"]//a')
+    if len(actors) > 0:
+        for actorLink in actors:
+            actorName = actorLink.text_content()
+            actorPageURL = PAsearchSites.getSearchBaseURL(siteID) + actorLink.get("href")
+            actorPage = HTML.ElementFromURL(actorPageURL)
+            actorPhotoURL = actorPage.xpath('//div[contains(@class,"u-ratio--model-poster")]//img/@data-src')
+            movieActors.addActor(actorName,actorPhotoURL[0])
+
+    # Posters/Background
+    valid_names = list()
+    metadata.posters.validate_keys(valid_names)
+    metadata.art.validate_keys(valid_names)
+    posters = detailsPageElements.xpath('//a[@class="u-block u-ratio u-ratio--lightbox u-bgc--bg-opt u-z--zero"]')
+    posterNum = 1
+    for posterCur in posters:
+        posterURLfull = posterCur.get("href").split('?')
+        posterURL = posterURLfull[0]
+        metadata.posters[posterURL] = Proxy.Preview(HTTP.Request(posterURL, headers={'Referer': 'http://www.google.com'}).content, sort_order = posterNum)
+        metadata.art[posterURL] = Proxy.Preview(HTTP.Request(posterURL, headers={'Referer': 'http://www.bing.com'}).content, sort_order = posterNum)
+        posterNum = posterNum + 1
+
+    backgroundStyle = detailsPageElements.xpath('//div[@class="splash-screen fullscreen-message is-visible"]')[0].get("style")
+    alpha = backgroundStyle.find('url(')+4
+    omega = backgroundStyle.find('.jpg')+4
+    background = backgroundStyle[alpha:omega]
+    metadata.art[background] = Proxy.Preview(HTTP.Request(background, headers={'Referer': 'http://www.google.com'}).content, sort_order = 1)
+
+    return metadata

--- a/Contents/Code/siteSLR.py
+++ b/Contents/Code/siteSLR.py
@@ -1,0 +1,81 @@
+import PAsearchSites
+import PAgenres
+import PAactors
+import PAutils
+
+
+def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchDate):
+    url = PAsearchSites.getSearchSearchURL(siteNum) + searchTitle.lower().replace(" ","-")
+    searchResults = HTML.ElementFromURL(url)
+
+    titleNoFormatting = searchResults.xpath('//h1')[0].text_content().strip()
+    curID = searchTitle.lower().replace(" ","-", 1).replace(" ","-")
+    Log('CURID: ' +  curID)
+    releaseDate = parse(searchResults.xpath('//time')[0].get('datetime')).strftime('%Y-%m-%d')
+
+    score = 100
+    results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum), name = titleNoFormatting + " ["+ PAsearchSites.getSearchSiteName(siteNum) +"] " + releaseDate, score = score, lang = lang))
+    return results
+
+
+def update(metadata,siteID,movieGenres,movieActors):
+    Log('******UPDATE CALLED*******')
+    temp = str(metadata.id).split("|")[0]
+    url = PAsearchSites.getSearchSearchURL(siteID) + temp
+    detailsPageElements = HTML.ElementFromURL(url)
+    art = []
+    metadata.collections.clear()
+	
+    # Studio/Tagline/Collection
+    metadata.studio = detailsPageElements.xpath('//div[(contains(@class,"u-block"))]/span/a/span')[0].text_content().strip()
+    metadata.tagline = metadata.studio
+    metadata.collections.clear()
+    metadata.collections.add(metadata.studio)
+
+    # Genres
+    movieGenres.clearGenres()
+    genres = detailsPageElements.xpath('//a[@class="u-wh u-fs--fo hover:u-lw u-transition--base u-mr--one u-lh--opt"]')
+    if len(genres) > 0:
+        for genre in genres:
+            movieGenres.addGenre(genre.text_content().lower())
+
+
+    # Actors
+    movieActors.clearActors()
+    actors = detailsPageElements.xpath('//a[@class="u-wh u-fs--fo hover:u-lw u-transition--base u-mr--one"]')
+    if len(actors) > 0:
+        for actorLink in actors:
+            actorName = actorLink.text_content()
+            actorPageURL = PAsearchSites.getSearchBaseURL(siteID) + actorLink.get("href")
+            actorPage = HTML.ElementFromURL(actorPageURL)
+            actorPhotoURL = actorPage.xpath('//div[(contains(@class,"u-ratio u-ratio--top u-ratio--model u-radius--two"))]/img/@data-src')
+            movieActors.addActor(actorName,actorPhotoURL[0])
+		
+    # TITLE
+    title = detailsPageElements.xpath('//div[(contains(@class,"u-inline-block u-align-y--m desktop:u-ml--four"))]/h1')[0].text_content().strip()
+    metadata.title = title
+    Log('Title: ' +  metadata.title)
+
+    # Summary
+    metadata.summary = detailsPageElements.xpath('//div[(contains(@class,"u-mb--four u-lh--opt u-fs--fo u-fw--medium u-lw"))]')[0].text_content().strip()
+    Log('summary: ' +  metadata.summary)
+	
+    # Date
+    date_object = parse(detailsPageElements.xpath('//time[@class="u-inline-block u-align-y--m u-wh u-fw--bold"]')[0].text_content().strip())
+    metadata.originally_available_at = date_object
+    metadata.year = metadata.originally_available_at.year
+	
+    # Posters/Background
+    valid_names = list()
+    metadata.posters.validate_keys(valid_names)
+    metadata.art.validate_keys(valid_names)
+    posters = detailsPageElements.xpath('//a[(contains(@class,"u-block u-ratio u-ratio--lightbox u-bgc--bg-opt u-z--zero"))]')
+    posterNum = 1
+    for posterCur in posters:
+        posterURL = posterCur.get('href')
+        metadata.posters[posterURL] = Proxy.Preview(HTTP.Request(posterURL, headers={'Referer': 'http://www.google.com'}).content, sort_order = posterNum)
+        posterNum = posterNum + 1		
+    backgroundURL = detailsPageElements.xpath('//meta[@property="og:image"]')[0].get('content').split('?')
+    metadata.art[backgroundURL[0]] = Proxy.Preview(HTTP.Request(backgroundURL[0], headers={'Referer': 'http://www.google.com'}).content, sort_order = 1)
+
+    return metadata

--- a/Contents/Code/siteXVirtual.py
+++ b/Contents/Code/siteXVirtual.py
@@ -1,0 +1,72 @@
+import PAsearchSites
+import PAgenres
+import PAactors
+import PAutils
+
+
+def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchDate):
+    searchString = encodedTitle.replace(" ","+")
+    searchResults = HTML.ElementFromURL(PAsearchSites.getSearchSearchURL(siteNum) + searchString)
+    Log("Results found: " + str(len(searchResults.xpath('//div[contains(@class,"episode__preview")]'))))
+    i = 0
+    for searchResult in searchResults.xpath('//div[contains(@class,"episode__preview")]/div[contains(@class,"episode__title")]/a/h2'):
+        titleNoFormatting = searchResult.xpath('//div[contains(@class,"episode__preview")]/div[contains(@class,"episode__title")]/a/h2')[i].text_content().title().strip()
+        Log ("Title: " +titleNoFormatting)
+        curID = PAutils.Encode(searchResult.xpath('//div[contains(@class,"episode__preview")]/div[contains(@class,"episode__title")]/a')[i].get('href'))
+        Log("curID: " +curID)
+        releaseDate = ""
+        Log("No date available (XVirtual)")
+        score = 100 - Util.LevenshteinDistance(searchTitle.lower(), titleNoFormatting.lower())
+        Log("Score: " + str(score))
+        results.Append(MetadataSearchResult(id = curID + "|" + str(siteNum) + "|" + releaseDate, name = titleNoFormatting + " [" + PAsearchSites.getSearchSiteName(siteNum) + "] " + releaseDate, score = score, lang = lang))
+        i = i +1
+    return results
+
+
+def update(metadata,siteID,movieGenres,movieActors):
+    Log('******UPDATE CALLED*******')
+
+    path = PAutils.Decode(str(metadata.id).split("|")[0])
+    url = PAsearchSites.getSearchBaseURL(siteID) + path
+    detailsPageElements = HTML.ElementFromURL(url)
+    art = []
+    metadata.collections.clear()
+    movieGenres.clearGenres()
+    movieActors.clearActors()
+
+    # Studio/Tagline/Collection
+    metadata.studio = PAsearchSites.getSearchSiteName(siteID)
+    metadata.tagline = metadata.studio
+    metadata.collections.clear()
+    metadata.collections.add(metadata.studio)
+
+    # TITLE
+    title = detailsPageElements.xpath('//div[contains(@class,"title")]/h2')[0].text_content().strip()
+    metadata.title = title
+    Log('Title: ' +  metadata.title)
+	
+    # Genres
+    movieGenres.clearGenres()
+    genres = detailsPageElements.xpath('//ul[contains(@class,"tags")]//a')
+    for genreLink in genres:
+        genreName = genreLink.text_content().strip().lower()
+        movieGenres.addGenre(genreName)
+	
+    # Summary
+    metadata.summary = detailsPageElements.xpath('//div[contains(@class,"description")]/div[contains(@class,"desc-text")]/p')[0].text_content().strip()
+    Log('summary: ' +  metadata.summary)
+	
+    # Posters/Background
+    valid_names = list()
+    metadata.posters.validate_keys(valid_names)
+    metadata.art.validate_keys(valid_names)
+    posters = detailsPageElements.xpath('//div[contains(@class,"thumbnails small-block-grid-2 medium-block-grid-3")]/a/img')
+    posterNum = 1
+    for posterCur in posters:
+        posterURL = posterCur.get('src')
+        metadata.posters[posterURL] = Proxy.Preview(HTTP.Request(posterURL, headers={'Referer': 'http://www.google.com'}).content, sort_order = posterNum)
+        posterNum = posterNum + 1
+    backgroundURL = detailsPageElements.xpath('//meta[@property="og:image"]')[0].get('content').split('?')
+    metadata.art[backgroundURL[0]] = Proxy.Preview(HTTP.Request(backgroundURL[0], headers={'Referer': 'http://www.google.com'}).content, sort_order = 1)
+	
+    return metadata

--- a/docs/sitelist.md
+++ b/docs/sitelist.md
@@ -925,7 +925,7 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
   - Hardx
   - Lesbianx
   - AllBlackX
-+ #### XVirtual | atching type: *[Limited](./manualsearch.md#limited-search)* - **Title only**
++ #### XVirtual | Matching type: *[Limited](./manualsearch.md#limited-search)* - **Title only**
 + #### Zero Tolerance | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)* - **DVDs not supported**
 
 ## Adding sites to this list

--- a/docs/sitelist.md
+++ b/docs/sitelist.md
@@ -229,6 +229,8 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
   - Hot Legs & Feet
   - House of Taboo
   - Only Blowjob
++ #### DefeatedXXX | Matching type: *[Limited](./manualsearch.md#limited-search)* - **Title and Date**
++ #### DefeatedSexFight | Matching type: *[Limited](./manualsearch.md#limited-search)* - **Title and Date**
 + #### Deviant Hardcore | Matching type: *[Limited](./manualsearch.md#limited-search)*
 + #### DigitalPlayground | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
 + #### Dogfart | Matching type: *[Limited](./manualsearch.md#limited-search)* - **Date Add**
@@ -741,6 +743,7 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
 + #### Other Reality Kings Sites | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
   - Lil Humpers
 + #### ReidMyLips | Matching type: *[Exact](./manualsearch.md#exact-match)* - **Direct URL**
++ #### SexLikeReal | Matching type: *[Exact](./manualsearch.md#exact-match)* - **Direct URL**
 + #### SexyHub | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
   - Dane Jones
   - Fitness Rooms
@@ -922,6 +925,7 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
   - Hardx
   - Lesbianx
   - AllBlackX
++ #### XVirtual | atching type: *[Limited](./manualsearch.md#limited-search)* - **Title only**
 + #### Zero Tolerance | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)* - **DVDs not supported**
 
 ## Adding sites to this list


### PR DESCRIPTION
- Fixed the issues DirtyRacer mentioned at the previous pull request (except SearchDate,ReleaseDate thingy which i didn't understand)
- Added support for LustReality
- Added support for SexLikeReal

DefeatedXXX and DefeatedSexfight
Successfully recovers Title, Date, Description (short version), Rating, Label, Posters and Backgrounds for old and new videos of both sites. (Old videos used another format for posters/background).
The title of the video should be as follows:
SiteName - Title
SiteName - YYYY-MM-DD - Title
SiteName - Title - YYYY-MM-DD
For me all the above are working!

XVirtual
Successfully recovers Title, Description (long version), Genres, Label, Posters and Backgrounds for XVirtual site. Site doesn't provide date or model information. :(
The title of the video should be as follows:
SiteName - Title
You can skip the in 180 degrees part.

LustReality
Successfully recovers Title, Description, Genres, Label, Posters, Actors and Backgrounds for LustReality site. 
The title of the video should be as follows:
SiteName - ID
Additional information can be added like:
SiteName - ID - Actors (this is what I use so i can search it through File Explorer too :)

SexLikeReal
Successfully recovers Title, Description, Genres, Label, Posters, Actors and Backgrounds for SexLikeReal site. 
The title of the video should be as follows:
SiteName - Exact URL 
I maybe try something else soon so Actors can be added.