### PR TITLE
networkKink Fix - Scene ID matching wasn't working

### DIFF
--- a/Contents/Code/networkKink.py
+++ b/Contents/Code/networkKink.py
@@ -14,7 +14,7 @@ def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchDate):
         detailsPageElements = HTML.ElementFromURL(PAsearchSites.getSearchBaseURL(siteNum) + url, headers={'Cookie': 'viewing-preferences=straight%2Cgay'})
 
         titleNoFormatting = detailsPageElements.xpath('//h1[@class="shoot-title"]')[0].text_content().strip()[:-1]
-        releaseDate = parse(detailsPageElements.xpath('//span[@class="shoot-date"]')[0].text_content().strip()).strftime('%B %d, %Y')
+        releaseDate = parse(detailsPageElements.xpath('//span[@class="shoot-date"]')[0].text_content().strip()).strftime('%Y-%m-%d')
         curID = url.replace('/','_').replace('?','!')
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='[%s] %s [%s] %s' % (shootID, titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=100, lang=lang))

--- a/Contents/Code/networkKink.py
+++ b/Contents/Code/networkKink.py
@@ -14,7 +14,7 @@ def search(results,encodedTitle,title,searchTitle,siteNum,lang,searchDate):
         detailsPageElements = HTML.ElementFromURL(PAsearchSites.getSearchBaseURL(siteNum) + url, headers={'Cookie': 'viewing-preferences=straight%2Cgay'})
 
         titleNoFormatting = detailsPageElements.xpath('//h1[@class="shoot-title"]')[0].text_content().strip()[:-1]
-        releaseDate = parse(detailsPageElements.xpath('//div[@class="columns"]/div[@class="column"]/p')[0].text_content().strip()[6:]).strftime('%Y-%m-%d')
+        releaseDate = parse(detailsPageElements.xpath('//span[@class="shoot-date"]')[0].text_content().strip()).strftime('%B %d, %Y')
         curID = url.replace('/','_').replace('?','!')
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='[%s] %s [%s] %s' % (shootID, titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=100, lang=lang))


### PR DESCRIPTION
Using a media title SiteName - ID - Whatever wasn't working lately on all Kink subsites, however SiteName - Title was working.
Found out that the releaseDate parameter the old parse strftime is not exist as xpath anymore at Kink sites so I replaced it. Now it's working!