### PR TITLE
Add Goldie Glock alias

### DIFF
--- a/Contents/Code/PAactors.py
+++ b/Contents/Code/PAactors.py
@@ -99,6 +99,8 @@ class PhoenixActors:
                 newActor = "Eve Laurence"
             elif newActor == "Francesca Di Caprio" or newActor == "Francesca Dicaprio":
                 newActor = "Francesca DiCaprio"
+            elif newActor == "Goldie":
+                newActor = "Goldie Glock"
             elif newActor == "Guiliana Alexis":
                 newActor = "Gulliana Alexis"
             elif newActor == "Grace Hartley":


### PR DESCRIPTION
On some sites Goldie Glock is simply named "Goldie" which messes up other movie libraries with the Actor and Musician [Goldie](https://www.themoviedb.org/person/1123329-goldie). fixes previous PR.