### PR TITLE
fix EvilAngel poster fetching

### DIFF
--- a/Contents/Code/networkGammaEntOther.py
+++ b/Contents/Code/networkGammaEntOther.py
@@ -150,7 +150,7 @@ def update(metadata, siteID, movieGenres, movieActors):
         art.append('https://images-fame.gammacdn.com/movies/{0}/{0}_{1}_front_400x625.jpg'.format(detailsPageElements['movie_id'], detailsPageElements['url_title'].lower().replace('-', '_')))
 
     if 'pictures' in detailsPageElements and detailsPageElements['pictures']:
-        keys = [key for key in detailsPageElements['pictures'].keys() if key[0].isdigit()]
+        keys = [key for key in detailsPageElements['pictures'].keys() if key and key[0].isdigit()]
         max_quality = sorted(keys)[-1]
         art.append('https://images-fame.gammacdn.com/movies/' + detailsPageElements['pictures'][max_quality])
 


### PR DESCRIPTION
Some scenes from EvilAngel have a pictures map entry which looks like this:
`u'': u'/9958/9958_03/previews/2/128/top_1_/9958_03_01.jpg'`
Since in this case the key is an empty string, a check is required to prevent an IndexError.