### PR TITLE
fix low res picture for old EvilAngel scenes

### DIFF
--- a/Contents/Code/networkGammaEntOther.py
+++ b/Contents/Code/networkGammaEntOther.py
@@ -4,6 +4,21 @@ import PAactors
 import PAutils
 
 
+def getMaxResolution(resolutions):
+    max_size = (None, 0)
+    for idx, key in enumerate(resolutions):
+        t = key.split('x')
+        if len(t) == 2:
+            size = int(t[0]) * int(t[1])
+            if size > max_size[1]:
+                max_size = idx, size
+
+    if max_size[0]:
+        return resolutions[max_size[0]]
+    
+    return None
+
+
 def getAPIKey(url):
     data = PAutils.HTTPRequest(url).text
     match = re.search(r'\"apiKey\":\"(.*?)\"', data)
@@ -158,9 +173,11 @@ def update(metadata, siteID, movieGenres, movieActors):
     if not PAsearchSites.getSearchBaseURL(siteID).endswith(('girlsway.com', 'puretaboo.com')):
         art.append('https://images-fame.gammacdn.com/movies/{0}/{0}_{1}_front_400x625.jpg'.format(detailsPageElements['movie_id'], detailsPageElements['url_title'].lower().replace('-', '_')))
 
-    if 'pictures' in detailsPageElements and detailsPageElements['pictures']['nsfw']['top']:
-        max_quality = detailsPageElements['pictures']['nsfw']['top'].keys()[0]
-        art.append('https://images-fame.gammacdn.com/movies/' + detailsPageElements['pictures'][max_quality])
+    if 'pictures' in detailsPageElements and detailsPageElements['pictures']:
+        keys = [key for key in detailsPageElements['pictures'].keys() if key and key[0].isdigit()]
+        max_quality = getMaxResolution(keys)
+        if max_quality:
+            art.append('https://images-fame.gammacdn.com/movies/' + detailsPageElements['pictures'][max_quality])
 
     Log('Artwork found: %d' % len(art))
     for idx, posterUrl in enumerate(art, 1):

--- a/Contents/Code/networkGammaEntOther.py
+++ b/Contents/Code/networkGammaEntOther.py
@@ -15,7 +15,7 @@ def getMaxResolution(resolutions):
 
     if max_size[0]:
         return resolutions[max_size[0]]
-    
+
     return None
 
 
@@ -156,7 +156,7 @@ def update(metadata, siteID, movieGenres, movieActors):
             max_quality = sorted(actorData['pictures'].keys())[-1]
             actorPhotoURL = 'https://images-fame.gammacdn.com/actors' + actorData['pictures'][max_quality]
         else:
-            actorPhotoURL = ''  
+            actorPhotoURL = ''
 
         if actorLink['gender'] == 'female':
             female.append((actorName, actorPhotoURL))

--- a/Contents/Code/networkGammaEntOther.py
+++ b/Contents/Code/networkGammaEntOther.py
@@ -158,9 +158,8 @@ def update(metadata, siteID, movieGenres, movieActors):
     if not PAsearchSites.getSearchBaseURL(siteID).endswith(('girlsway.com', 'puretaboo.com')):
         art.append('https://images-fame.gammacdn.com/movies/{0}/{0}_{1}_front_400x625.jpg'.format(detailsPageElements['movie_id'], detailsPageElements['url_title'].lower().replace('-', '_')))
 
-    if 'pictures' in detailsPageElements and detailsPageElements['pictures']:
-        keys = [key for key in detailsPageElements['pictures'].keys() if key and key[0].isdigit()]
-        max_quality = sorted(keys)[-1]
+    if 'pictures' in detailsPageElements and detailsPageElements['pictures']['nsfw']['top']:
+        max_quality = detailsPageElements['pictures']['nsfw']['top'].keys()[0]
         art.append('https://images-fame.gammacdn.com/movies/' + detailsPageElements['pictures'][max_quality])
 
     Log('Artwork found: %d' % len(art))


### PR DESCRIPTION
This change fixes fetching of low res pictures for old EA scenes. The problem was that the keys in the pictures dict got sorted as a string. That means that the following set of keys looked like this when sorted descending:

'76x55',
'720x480',
'638x360',
'307x224',
'201x147',
'185x135'

This is why 76x55 'wins' as the best resolution while being the lowest. 

Fortunately the highest resoution picture is always stored in `['pictures']['nsfw']['top']['WIDTHxHEIGHT']`
Tested across all _GammaEntOther_ sites.