### PR TITLE
Minor Fix SexLikeReal, VirtualRealPorn - Added sceneID support for HoloGirlsVR

### DIFF
--- a/Contents/Code/siteHoloGirlsVR.py
+++ b/Contents/Code/siteHoloGirlsVR.py
@@ -5,16 +5,30 @@ import PAutils
 
 
 def search(results, encodedTitle, searchTitle, siteNum, lang, searchDate):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + encodedTitle)
-    searchResults = HTML.ElementFromString(req.text)
-    for searchResult in searchResults.xpath('//div[@class="memVid"]'):
-        titleNoFormatting = searchResult.xpath('.//div[@class="memVidTitle"]//a/@title')[0]
-        curID = PAutils.Encode(searchResult.xpath('.//div[@class="memVidTitle"]//a/@href')[0])
+
+    splited = searchTitle.split(' ')
+    if unicode(splited[0], 'utf8').isdigit():
+        sceneID = splited[0]
+        searchTitle = searchTitle.replace(sceneID, '', 1).strip()
+        DirectURL = ('https://www.hologirlsvr.com/Scenes/Videos/' + sceneID)
+        req = PAutils.HTTPRequest(DirectURL)
+        searchResults = HTML.ElementFromString(req.text)
+        titleNoFormatting = searchResults.xpath('//div[@class="col-xs-12 video-title"]//h3')[0].text_content().strip()
+        curID = PAutils.Encode(DirectURL)
         releaseDate = parse(searchDate).strftime('%Y-%m-%d') if searchDate else ''
-
-        score = 100 - Util.LevenshteinDistance(searchTitle.lower(), titleNoFormatting.lower())
-
+        score = 100
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
+    else:
+        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + encodedTitle)
+        searchResults = HTML.ElementFromString(req.text)
+        for searchResult in searchResults.xpath('//div[@class="memVid"]'):
+            titleNoFormatting = searchResult.xpath('.//div[@class="memVidTitle"]//a/@title')[0]
+            curID = PAutils.Encode(searchResult.xpath('.//div[@class="memVidTitle"]//a/@href')[0])
+            releaseDate = parse(searchDate).strftime('%Y-%m-%d') if searchDate else ''
+
+            score = 100 - Util.LevenshteinDistance(searchTitle.lower(), titleNoFormatting.lower())
+
+            results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 
     return results
 

--- a/Contents/Code/siteSexLikeReal.py
+++ b/Contents/Code/siteSexLikeReal.py
@@ -14,20 +14,23 @@ def search(results, encodedTitle, searchTitle, siteNum, lang, searchDate):
             searchResults.append(sceneURL)
 
     for sceneURL in searchResults:
-        req = PAutils.HTTPRequest(sceneURL)
-        detailsPageElements = HTML.ElementFromString(req.text)
+        try:
+            req = PAutils.HTTPRequest(sceneURL)
+            detailsPageElements = HTML.ElementFromString(req.text)
 
-        if detailsPageElements:
-            curID = PAutils.Encode(sceneURL)
-            titleNoFormatting = detailsPageElements.xpath('//h1')[0].text_content().strip()
-            releaseDate = parse(detailsPageElements.xpath('//time/@datetime')[0]).strftime('%Y-%m-%d')
+            if detailsPageElements:
+                curID = PAutils.Encode(sceneURL)
+                titleNoFormatting = detailsPageElements.xpath('//h1')[0].text_content().strip()
+                releaseDate = parse(detailsPageElements.xpath('//time/@datetime')[0]).strftime('%Y-%m-%d')
 
-            if searchDate:
-                score = 100 - Util.LevenshteinDistance(searchDate, releaseDate)
-            else:
-                score = 100 - Util.LevenshteinDistance(searchTitle.lower(), titleNoFormatting.lower())
+                if searchDate:
+                    score = 100 - Util.LevenshteinDistance(searchDate, releaseDate)
+                else:
+                    score = 100 - Util.LevenshteinDistance(searchTitle.lower(), titleNoFormatting.lower())
 
-            results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
+                results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
+        except:
+            pass
 
     return results
 

--- a/Contents/Code/siteVirtualReal.py
+++ b/Contents/Code/siteVirtualReal.py
@@ -82,7 +82,7 @@ def update(metadata, siteID, movieGenres, movieActors):
     art = []
     xpaths = [
         '//dl8-video/@poster',
-        '//a[contains(@class,"w-gallery-tnail")]/@href'
+        '//figure[contains(@itemprop,"associatedMedia")]/a/@href'
     ]
     for xpath in xpaths:
         for poster in detailsPageElements.xpath(xpath):


### PR DESCRIPTION
SexLikeReal videos used first the directURL to search list and because of different filename the URL wasn't valid. That crashed the agent. A simple try-except is enough so in case directURL is not valid then the GoogleSearch item will continue.

Added sceneID support for HoloGirlsVR. SiteName - sceneID - Whatever

Fixed VirtualRealPorn art download. They changed how gallery is so it would download only the poster. Fixed to download the gallery too.