### PR TITLE
Fixed PAactors error,Added sceneID support for WankzVR-MilfVR,Added Support for AllAnalAllTheTime via sceneID

### DIFF
--- a/Contents/Code/PAactors.py
+++ b/Contents/Code/PAactors.py
@@ -2349,7 +2349,7 @@ class PhoenixActors:
             elif metadata.studio == 'Puffy Network':
                 if newActor == 'Stefany':
                     newActor = 'Stefanie Moon'
-            elif metadate.studio == 'HuCows.com':
+            elif metadata.studio == 'HuCows.com':
                 if newActor == 'Daisy':
                     newActor = 'Emma Green'
                 elif newActor == 'Liz':
@@ -2384,7 +2384,7 @@ class PhoenixActors:
                     newActor = 'Samantha Bentley'
                 elif newActor == 'Fayth':
                     newActor = 'Fayth On Fire'
-
+                    
             if not skip:
                 if newPhoto == '':
                     newPhoto = actorDBfinder(newActor)

--- a/Contents/Code/PAsearchSites.py
+++ b/Contents/Code/PAsearchSites.py
@@ -111,8 +111,9 @@ import siteVRConk
 import networkEvolvedFights
 import networkJavBus
 import siteHucows
+import siteAllAnalAllTheTime
 
-searchSites = [None] * 931
+searchSites = [None] * 932
 
 searchSites[0] = ("BlackedRaw", "BlackedRaw", "https://www.blackedraw.com", "https://www.blackedraw.com/api")
 searchSites[1] = ("Blacked", "Blacked", "https://www.blacked.com", "https://www.blacked.com/api")
@@ -1044,6 +1045,7 @@ searchSites[927] = ("Anal Channel PornPortal", "Anal Channel PornPortal", "https
 searchSites[928] = ("BBW Channel PornPortal", "BBW Channel PornPortal", "https://bbw-channel.pornportal.com", "https://site-api.project1service.com")
 searchSites[929] = ("VR Channel PornPortal", "VR Channel PornPortal", "https://vr-channel.pornportal.com", "https://site-api.project1service.com")
 searchSites[930] = ("Raw Couples", "Raw Couples", "http://teenmegaworld.net", "http://teenmegaworld.net/search.php?query=")
+searchSites[931] = ("All Anal All The Time", "All Anal All The Time", "https://www.allanalallthetime.com", "https://www.allanalallthetime.com/videos/")
 
 def getSearchBaseURL(siteID):
     return searchSites[siteID][2]

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -829,6 +829,10 @@ class PhoenixAdultAgent(Agent.Movies):
             elif (918 <= searchSiteID <= 929):
                 results = PAsearchSites.network1service.search(results, encodedTitle, searchTitle, siteNum, lang, searchDate)
 
+            # AllAnalAllTheTime
+            elif (searchSiteID == 931):
+                results = PAsearchSites.siteAllAnalAllTheTime.search(results, encodedTitle, searchTitle, siteNum, lang, searchDate)
+
         results.Sort('score', descending=True)
 
     def update(self, metadata, media, lang):
@@ -1443,6 +1447,10 @@ class PhoenixAdultAgent(Agent.Movies):
         # PornPortal
         elif (918 <= siteID <= 929):
             metadata = PAsearchSites.network1service.update(results, encodedTitle, searchTitle, siteNum, lang, searchDate)
+
+        # AllAnalAllTheTime
+        elif (siteID == 931):
+            metadata = PAsearchSites.siteAllAnalAllTheTime.update(metadata, siteID, movieGenres, movieActors)
 
         # Cleanup Genres and Add
         Log("Genres")

--- a/Contents/Code/siteAllAnalAllTheTime.py
+++ b/Contents/Code/siteAllAnalAllTheTime.py
@@ -1,0 +1,75 @@
+import PAsearchSites
+import PAgenres
+import PAutils
+
+
+def search(results, encodedTitle, searchTitle, siteNum, lang, searchDate):
+    sceneID = None
+    splited = searchTitle.split(' ')
+    if unicode(splited[0], 'utf8').isdigit():
+        sceneID = splited[0]
+        searchTitle = searchTitle.replace(sceneID, '', 1).strip()
+        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + sceneID)
+        searchResults = HTML.ElementFromString(req.text)
+        titleNoFormatting = searchResults.xpath('//h1[@class="customhcolor"]')[0].text_content()
+        curID = PAutils.Encode(PAsearchSites.getSearchSearchURL(siteNum) + sceneID)
+
+        releaseDate = ''
+        date = searchResults.xpath('//div[@class="date"]')[0].text_content().strip()
+        if date:
+            releaseDate = parse(date).strftime('%Y-%m-%d')
+
+        score = 100
+        
+    results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='[%s] %s %s' % (PAsearchSites.getSearchSiteName(siteNum), titleNoFormatting, releaseDate), score=score, lang=lang))
+
+    return results
+
+def StringToList(string): 
+    li = list(string.split(",")) 
+    return li 
+
+def update(metadata, siteID, movieGenres, movieActors):
+    metadata_id = str(metadata.id).split('|')
+    sceneURL = PAutils.Decode(metadata_id[0])
+    req = PAutils.HTTPRequest(sceneURL)
+    detailsPageElements = HTML.ElementFromString(req.text)
+    art = []
+
+    # Title
+    metadata.title = detailsPageElements.xpath('//h1[@class="customhcolor"]')[0].text_content()
+
+    # Summary
+    metadata.summary = detailsPageElements.xpath('//div[@class="customhcolor2"]')[0].text_content().strip()
+
+    # Studio
+    metadata.studio = PAsearchSites.getSearchSiteName(siteID)
+
+    # Tagline and Collection(s)
+    metadata.collections.clear()
+    metadata.tagline = metadata.studio
+    metadata.collections.add(metadata.studio)
+
+    # Release Date
+    date = detailsPageElements.xpath('//div[@class="date"]')[0].text_content().strip()
+    date_object = parse(date)
+    metadata.originally_available_at = date_object
+    metadata.year = metadata.originally_available_at.year
+
+    # Genres
+    movieGenres.clearGenres()
+    genrestring = detailsPageElements.xpath('//h4[@class="customhcolor"]')[0].text_content().strip()
+    genres = StringToList(genrestring)
+    for genre in genres:
+        movieGenres.addGenre(genre)
+
+    # Actors / possible posters
+    movieActors.clearActors()
+    actors = detailsPageElements.xpath('//h3[@class="customhcolor"]')
+    for actor in actors:
+        actorName = actor.text_content().strip()
+        actorPhotoURL = ''
+        art.append(actorPhotoURL)
+        movieActors.addActor(actorName, actorPhotoURL)
+
+    return metadata

--- a/Contents/Code/siteMilfVR.py
+++ b/Contents/Code/siteMilfVR.py
@@ -4,22 +4,43 @@ import PAutils
 
 
 def search(results, encodedTitle, searchTitle, siteNum, lang, searchDate):
-    encodedTitle = searchTitle.replace(' ', '+')
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + encodedTitle, cookies={
+    sceneID = None
+    splited = searchTitle.split(' ')
+    if unicode(splited[0], 'utf8').isdigit():
+        sceneID = splited[0]
+        searchTitle = searchTitle.replace(sceneID, '', 1).strip()
+        req = PAutils.HTTPRequest((PAsearchSites.getSearchBaseURL(siteNum) + '/' + sceneID), cookies={
         'sst': 'ulang-en'
-    })
-    searchResults = HTML.ElementFromString(req.text)
-    for searchResult in searchResults.xpath('//ul[@class="cards-list"]//li'):
-        titleNoFormatting = searchResult.xpath('.//div[@class="card__footer"]//div[@class="card__h"]/text()')[0]
-        curID = PAutils.Encode(searchResult.xpath('.//a/@href')[0])
-        releaseDate = parse(searchResult.xpath('.//div[@class="card__date"]')[0].text_content().strip()).strftime('%Y-%m-%d')
+        })
+        searchResults = HTML.ElementFromString(req.text)
+        titleNoFormatting = searchResults.xpath('//h1[@class="detail__title"]')[0].text_content()
+        curID = PAutils.Encode(PAsearchSites.getSearchBaseURL(siteNum) + '/' + sceneID)
 
-        if searchDate:
-            score = 100 - Util.LevenshteinDistance(searchDate, releaseDate)
-        else:
-            score = 100 - Util.LevenshteinDistance(searchTitle.lower(), titleNoFormatting.lower())
+        releaseDate = ''
+        date = searchResults.xpath('//span[@class="detail__date"]')[0].text_content().strip()
+        if date:
+            releaseDate = parse(date).strftime('%Y-%m-%d')
 
-        results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
+        score = 100
+        results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='[%s] %s %s' % (PAsearchSites.getSearchSiteName(siteNum), titleNoFormatting, releaseDate), score=score, lang=lang))
+    
+    else:
+        encodedTitle = searchTitle.replace(' ', '+')
+        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + encodedTitle, cookies={
+            'sst': 'ulang-en'
+        })
+        searchResults = HTML.ElementFromString(req.text)
+        for searchResult in searchResults.xpath('//ul[@class="cards-list"]//li'):
+            titleNoFormatting = searchResult.xpath('.//div[@class="card__footer"]//div[@class="card__h"]/text()')[0]
+            curID = PAutils.Encode(searchResult.xpath('.//a/@href')[0])
+            releaseDate = parse(searchResult.xpath('.//div[@class="card__date"]')[0].text_content().strip()).strftime('%Y-%m-%d')
+
+            if searchDate:
+                score = 100 - Util.LevenshteinDistance(searchDate, releaseDate)
+            else:
+                score = 100 - Util.LevenshteinDistance(searchTitle.lower(), titleNoFormatting.lower())
+
+            results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 
     return results
 

--- a/docs/sitelist.md
+++ b/docs/sitelist.md
@@ -26,6 +26,7 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
   - Gapeland
   - LezCuties
   - PixandVideo
++ #### AllAnalAllTheTime | Matching type: *[Exact](./manualsearch.md#exact-match)* - **SceneID**
 + #### AllHerLuv | Matching type: *[Limited](./manualsearch.md#limited-search)*
 + #### Amateur Allure | Matching type: *[Limited](./manualsearch.md#limited-search)*
 + #### AmourAngels | Matching type: *[Exact](./manualsearch.md#exact-match)* - **SceneID**


### PR DESCRIPTION
- metadate.studio typo at PAactors didn't return Actor metadata (Name,Photo) back to the plex (agent crashed). changed to metadata.studio

- SceneID support for WankzVR-MilfVR as i did with BaDoinkVR networks.

- Added support for AllAnalAllTheTime via sceneID. 
Title should be SiteName - SceneID - Whatever
Problem to find-collect the actorPhotoURL from this site. I got a lot of server didn't respond in time. Also they don't provide a link to actor Page (Join Now! redirect). Possibly can be collected via Models page. Choose the first letter of our model then redirect to the 'C' and then scrape through all of them and do name-string comparison.