### PR TITLE
Fix 18OnlyGirls - Move to New Source Site & Enhance Search

### DIFF
--- a/Contents/Code/PAsearchSites.py
+++ b/Contents/Code/PAsearchSites.py
@@ -926,7 +926,7 @@ searchSites[790] = ("BCM", "BCM.XXX", "https://www.pimp.xxx", "https://pimp.xxx/
 searchSites[791] = ("Petite", "Petite.XXX", "https://www.pimp.xxx", "https://pimp.xxx/search.php?query=")
 searchSites[792] = ("Family", "Family.XXX", "https://www.family.xxx", "https://family.xxx/search.php?query=")
 searchSites[793] = ("Wicked", "Wicked Pictures", "https://www.wicked.com", "https://tsmkfa364q-dsn.algolia.net/1/indexes/*/queries")
-searchSites[794] = ("18OnlyGirls", "18 Only Girls", "http://www.18onlygirls.tv", "http://18onlygirls.tv/?s=")
+searchSites[794] = ("18OnlyGirls", "18 Only Girls", "https://www.18onlygirlsblog.com/", "https://www.18onlygirlsblog.com/?s=")
 searchSites[795] = ("GirlCore", "GirlCore", "https://www.girlsway.com", "https://www.girlsway.com/en/video/1/1/")
 searchSites[796] = ("Moms On Moms", "Moms On Moms", "https://www.girlsway.com", "https://www.girlsway.com/en/video/1/1/")
 searchSites[797] = ("We Like Girls", "We Like Girls", "https://www.girlsway.com", "https://www.girlsway.com/en/video/1/1/")

--- a/Contents/Code/site18OnlyGirls.py
+++ b/Contents/Code/site18OnlyGirls.py
@@ -47,7 +47,6 @@ def update(metadata, siteID, movieGenres, movieActors):
 
     if '-2' in sceneURL:
         photosetURL = sceneURL.replace('-2','')
-        Log('Photo URL: %s' % photosetURL)
         req = PAutils.HTTPRequest(photosetURL)
         photosetPageElements = HTML.ElementFromString(req.text)
 

--- a/Contents/Code/site18OnlyGirls.py
+++ b/Contents/Code/site18OnlyGirls.py
@@ -85,7 +85,8 @@ def update(metadata, siteID, movieGenres, movieActors):
     # Actors
     movieActors.clearActors()
     actors = detailsPageElements.xpath('//div[@itemprop="actor"]//a')
-
+    actorPhotoURL = ''
+    
     if len(actors) > 0:
         if len(actors) == 3:
             movieGenres.addGenre('Threesome')
@@ -97,7 +98,6 @@ def update(metadata, siteID, movieGenres, movieActors):
         for actorLink in actors:
             actorName = str(actorLink.text_content().strip())
             actorPageURL = 'https://18onlygirls.tv/models/' + actorName.replace(' ', '-')
-            actorPhotoURL = 'https://18onlygirls.tv/models/' + actorName.replace(' ', '-')
             req = PAutils.HTTPRequest(actorPageURL)
 
             try:

--- a/Contents/Code/site18OnlyGirls.py
+++ b/Contents/Code/site18OnlyGirls.py
@@ -86,7 +86,7 @@ def update(metadata, siteID, movieGenres, movieActors):
     movieActors.clearActors()
     actors = detailsPageElements.xpath('//div[@itemprop="actor"]//a')
     actorPhotoURL = ''
-    
+
     if len(actors) > 0:
         if len(actors) == 3:
             movieGenres.addGenre('Threesome')
@@ -118,6 +118,8 @@ def update(metadata, siteID, movieGenres, movieActors):
     ]
     for xpath in xpaths:
         try:
+            for poster in detailsPageElements.xpath(xpath):
+                art.append(poster)
             for poster in photosetPageElements.xpath(xpath):
                 art.append(poster)
         except:
@@ -133,10 +135,10 @@ def update(metadata, siteID, movieGenres, movieActors):
                 resized_image = Image.open(im)
                 width, height = resized_image.size
                 # Add the image proxy items to the collection
-                if width < 801:
+                if width < height:
                     # Item is a poster
                     metadata.posters[posterUrl] = Proxy.Media(image.content, sort_order=idx)
-                if width == 1200:
+                if width > height:
                     # Item is an art item
                     metadata.art[posterUrl] = Proxy.Media(image.content, sort_order=idx)
             except:

--- a/docs/sitelist.md
+++ b/docs/sitelist.md
@@ -9,7 +9,7 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
 + #### 5Kporn | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
   - 5Kporn
   - 5Kteens
-+ #### 18OnlyGirls | Matching type: *[Limited](./manualsearch.md#limited-search)* - **Date Add**
++ #### 18OnlyGirls | Matching type: *[Enhanced](./manualsearch.md#Enhanced-search)*
 + #### 21Naturals | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
   - 21Naturals
   - 21FootArt


### PR DESCRIPTION
The current site for 18 Only Girls is rather limited in that the titles of Movies don't match what is listed on the site and the site is not up to date.

- Switching to "www.18onlygirlsblog.com" improves the chances of a match. 
- The new site also sometimes has image sets separate from the videos. 
- Description is not always available. 
- Actor image taken from old site "https://18onlygirls.tv/models/" if one exists, as the new site does not have actor images.

Enhanced Search Results:
- Suggest using Partial Title (full title does not always seem to work)
- Actor Name will also work
- Image Set results are filtered out to avoid duplicate results (the image set is grabbed with the video if it exists)

