### PR TITLE
Added Support for Sicflics.com, improved addActors.py code

### DIFF
--- a/Contents/Code/PAsearchSites.py
+++ b/Contents/Code/PAsearchSites.py
@@ -130,8 +130,9 @@ import sitePornstarPlatinum
 import siteWoodmanCastingX
 import networkScoreGroup
 import siteTwoTGirls
+import siteSicflics
 
-searchSites = [None] * 1023
+searchSites = [None] * 1024
 
 searchSites[0] = ("BlackedRaw", "BlackedRaw", "https://www.blackedraw.com", "https://www.blackedraw.com/api")
 searchSites[1] = ("Blacked", "Blacked", "https://www.blacked.com", "https://www.blacked.com/api")
@@ -1155,6 +1156,7 @@ searchSites[1019] = ("Big Boob Bundle", "Big Boob Bundle", "https://www.bigboobb
 searchSites[1020] = ("Leg Sex", "Leg Sex", "https://www.legsex.com", "https://www.legsex.com/foot-fetish-videos/")
 searchSites[1021] = ("Scoreland", "Scoreland", "https://www.scoreland.com", "https://www.scoreland.com/big-boob-videos/")
 searchSites[1022] = ("TwoTGirls", "TwoTGirls", "https://twotgirls.com/", "https://twotgirls.com/videos?query=")
+searchSites[1023] = ("Sicflics", "Sicflics", "https://www.sicflics.com/", "https://www.sicflics.com/tags/")
 
 def getSearchBaseURL(siteID):
     return searchSites[siteID][2]

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -920,6 +920,10 @@ class PhoenixAdultAgent(Agent.Movies):
             elif searchSiteID == 1022:
                 results = PAsearchSites.siteTwoTGirls.search(results, encodedTitle, searchTitle, siteNum, lang, searchDate)
 
+            # Sicflics
+            elif searchSiteID == 1023:
+                results = PAsearchSites.siteSicflics.search(results, encodedTitle, searchTitle, siteNum, lang, searchDate)
+
         results.Sort('score', descending=True)
 
     def update(self, metadata, media, lang):
@@ -1618,6 +1622,11 @@ class PhoenixAdultAgent(Agent.Movies):
         # TwoTGirls
         elif siteID == 1022:
             results = PAsearchSites.siteTwoTGirls.update(metadata, siteID, movieGenres, movieActors)
+
+        # Sicflics
+        elif siteID == 1023:
+            results = PAsearchSites.siteSicflics.update(metadata, siteID, movieGenres, movieActors)
+
 
         # Cleanup Genres and Add
         Log("Genres")

--- a/Contents/Code/addActors.py
+++ b/Contents/Code/addActors.py
@@ -5,20 +5,20 @@ import PAactors
 
 def search(results, encodedTitle, searchTitle, siteNum, lang, searchDate):
     Log("searchTitle:" + searchTitle)
-    searchTitle = searchTitle.replace(' And ',',').replace(' and ',',').replace(' In ', ' in ').replace(' At ', ' at ')
-    parse_siteName = searchTitle.split(' at ')
+    searchTitle = searchTitle.replace(' AND ',' and ').replace(' And ',' and ').replace(' In ', ' in ').replace(' At ', ' at ')
+    parse_siteName = searchTitle.rsplit(' at ', 1) # only split on last 'at'
     if len(parse_siteName) > 1:
-        siteName = parse_siteName[1].strip().title()
+        siteName = parse_siteName[1].strip()
         Log("Manual Site Name: " + siteName)
     else:
         siteName = ''
-    parse_sceneName = parse_siteName[0].split(' in ')
+    parse_sceneName = parse_siteName[0].split(' in ', 1) # only split on first 'in'
     if len(parse_sceneName) > 1:
         sceneName = parse_sceneName[1].strip().title()
         Log("Manual Scene Name: " + sceneName)
     else:
         sceneName = ''
-    actors = parse_sceneName[0].split(",")
+    actors = parse_sceneName[0].split("and")
     actorsFormatted = []
     for actor in actors:
         actorsFormatted.append(actor.strip().title())

--- a/Contents/Code/siteInTheCrack.py
+++ b/Contents/Code/siteInTheCrack.py
@@ -58,6 +58,10 @@ def update(metadata, siteID, movieGenres, movieActors):
     # Title
     metadata.title = detailsPageElements.xpath('//h2//span')[0].text_content().strip()
 
+    # Summary
+    for searchResult in detailsPageElements.xpath('//p[@id="CollectionDescription"]'):
+        metadata.summary = searchResult.text_content().strip()
+
     # Studio
     metadata.studio = 'InTheCrack'
 

--- a/Contents/Code/siteSicflics.py
+++ b/Contents/Code/siteSicflics.py
@@ -1,0 +1,102 @@
+import PAsearchSites
+import PAgenres
+import PAactors
+import re
+import PAutils
+
+
+def search(results, encodedTitle, searchTitle, siteNum, lang, searchDate):
+    firstpage = PAsearchSites.getSearchSearchURL(siteNum) + encodedTitle + "/page1.html"
+    req = PAutils.HTTPRequest(firstpage)
+    searchResults = HTML.ElementFromString(req.text)
+    for searchResult in searchResults.xpath('//nav[@aria-label="pagination-top"]//div[@class="dropdown-menu"]/a[@class="dropdown-item"]'):
+        pageURL = searchResult.xpath('./@href')[0]
+        req = PAutils.HTTPRequest(pageURL)
+        pageResults = HTML.ElementFromString(req.text)
+        for pageResult in pageResults.xpath('//li[@class="col-sm-6 col-lg-4"]'):
+            imgURL = pageResult.xpath('.//div[@class="vidthumb"]/a[@class="diagrad"]/img/@src')[0]
+            curID = PAutils.Encode(imgURL)
+            titleNoFormatting = pageResult.xpath('.//div[@class="vidtitle"]/p[1]')[0].text_content().strip()
+            # Release Date
+            date = ''
+            try:
+                date = pageResult.xpath('.//div[@class="vidtitle"]/p[2]')[0].text_content().strip()
+            except:
+                pass
+            releaseDate = parse(date).strftime('%Y-%m-%d') if date else ''
+            description = pageResult.xpath('.//div[@class="collapse"]/p')[0].text_content().split(':')[1].strip()
+            description = PAutils.Encode(description)
+
+            score = 100 - Util.LevenshteinDistance(searchDate, releaseDate)
+            results.Append(MetadataSearchResult(id='%s|%d|%s|%s|%s' % (curID, siteNum, releaseDate, titleNoFormatting, description), name='%s %s [%s]' % (titleNoFormatting, releaseDate, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
+
+    return results
+
+
+def update(metadata, siteID, movieGenres, movieActors):
+    metadata_id = str(metadata.id).split('|')
+    imgURL = PAutils.Decode(metadata_id[0])
+    if not imgURL.startswith('http'):
+        imgURL = PAsearchSites.getSearchBaseURL(siteID) + imgURL
+
+    # Studio
+    metadata.studio = 'Sicflics'
+
+    # Title
+    metadata.title = PAutils.Decode(metadata_id[3])
+
+    # Summary
+    description = PAutils.Decode(metadata_id[4])
+    if description:
+        metadata.summary = description.replace('\n', '').strip()
+    Log(metadata.summary)
+
+    # Tagline and Collection(s)
+    metadata.collections.clear()
+    tagline = PAsearchSites.getSearchSiteName(siteID).strip()
+    metadata.tagline = tagline
+    metadata.collections.add(tagline)
+
+    # Genres TODO: get genres from homepage
+    movieGenres.clearGenres()
+    movieGenres.addGenre("Extreme")
+
+    # Release Date
+    date_object = parse(PAutils.Decode(metadata_id[2]))
+    metadata.originally_available_at = date_object
+    metadata.year = metadata.originally_available_at.year
+
+    # Actors
+    movieActors.clearActors()
+    description = description.encode('ascii', 'replace')
+    actorName = re.split("['?]", description)[1].strip()
+    actorPhotoURL = ''
+    if actorName:
+        movieActors.addActor(actorName, actorPhotoURL)
+
+    # Posters
+    art = []
+
+    if imgURL:
+        art.append(imgURL)
+
+    Log('Artwork found: %d' % len(art))
+    for idx, posterUrl in enumerate(art, 1):
+        if not PAsearchSites.posterAlreadyExists(posterUrl, metadata):
+            # Download image file for analysis
+            try:
+                image = PAutils.HTTPRequest(posterUrl, headers={'Referer': 'http://www.google.com'})
+                im = StringIO(image.content)
+                resized_image = Image.open(im)
+                width, height = resized_image.size
+                # Add the image proxy items to the collection
+                if width > 1 or height > width:
+                    # Item is a poster
+                    metadata.posters[posterUrl] = Proxy.Media(image.content, sort_order=idx)
+                if width > 100 and width > height:
+                    # Item is an art item
+                    metadata.art[posterUrl] = Proxy.Media(image.content, sort_order=idx)
+            except:
+                pass
+
+    return metadata

--- a/docs/sitelist.md
+++ b/docs/sitelist.md
@@ -813,6 +813,7 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
 + #### Screwbox | Matching type: *[Limited](./manualsearch.md#limited-search)*
 + #### ScrewMeToo | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
 + #### She Will Cheat | Matching type: *[Limited](./manualsearch.md#limited-search)*
++ #### Sicflics | Matching type: *[Exact](./manualsearch.md#exact-match)* - **Actress name with Date Add**
 + #### SinsLife | Matching type: *[Limited](./manualsearch.md#limited-search)*
 + #### SinX | Matching type: *[Limited](./manualsearch.md#limited-search)*
   - Fully Clothed Pissing


### PR DESCRIPTION
Added support for sicflics.com:

> Exact search:
> sicflics - [date] - [actress]
> Example:
> sicflics - 2019-10-14 - Lilly Fuck Slut
> 
> It works as follows: by entering the name of the actress, the scraper loads all the scenes for that actress, and uses the date of the scene to calculate the match score. I did not use the sites search function, as it can only load 1 page every 8 seconds so it could only display the results of the first page.

Improved addActors code:

> Code would split on every 'at' and on every 'in', it would also replace every 'and' in the scenetitle with ','
> So I did the following:
> - only split on last 'at' so that any 'at' in the scenetitle will be kept;
> - only split on first 'in' so that any 'in' in the scenetitle will be kept;
> - split actors on 'and', not on ',' so that any 'and' in the scenetitle will be kept (no need to replace every 'and' with ',');
> - removed the .title() called on the sitename, so that formatting of the sitename will be kept: e.g. TestSite would be converted tot Testsite, which is not always the desired outcome.