### PR TITLE
Suggestion: Title Case Parser

### DIFF
--- a/Contents/Code/PAutils.py
+++ b/Contents/Code/PAutils.py
@@ -214,10 +214,10 @@ def parseTitle(s):
     for word in word_list[1:]:
         final.append(parseWord(word))
 
-    output = " ".join(final)
-    output = re.sub(r"\b(?:\.)$", "", output)
-    output = re.sub(r"\.(?=([a-z]))", ". ", output)
-    output = re.sub(r"\s+([.,!\":])", "", output)
+    output = ' '.join(final)
+    output = re.sub(r'\b(?:\.)$', '', output)
+    output = re.sub(r'\.(?=([a-z]))', '. ', output)
+    output = re.sub(r'\s+([.,!\":])', '', output)
 
     return output
 

--- a/Contents/Code/PAutils.py
+++ b/Contents/Code/PAutils.py
@@ -198,6 +198,7 @@ def saveRequest(url, req):
 
     return True
 
+
 def parseTitle(s):
     s = re.sub(r'w\/(?!\s)', 'w/ ', s, flags=re.IGNORECASE)
     s = re.sub(r'\,(?!\s)', ', ', s)
@@ -221,12 +222,13 @@ def parseTitle(s):
 
     return output
 
+
 def parseWord(word):
     word_exceptions = ['a', 'an', 'of', 'the', 'to', 'and', 'by', 'for', 'on', 'to', 'onto', 'but', 'or', 'nor', 'at', 'with', 'vs.', 'vs']
     adult_exceptions = ['bbc', 'xxx', 'bbw', 'bf', 'bff']
-    capital_exceptions = ['A','V']
+    capital_exceptions = ['A', 'V']
 
-    if '-' in word and not '--' in word:
+    if '-' in word and '--' not in word:
         word_list = re.split('-', word)
 
         firstword = parseWord(word_list[0])
@@ -243,7 +245,7 @@ def parseWord(word):
         final = nhword
     elif word.lower() in adult_exceptions:
         final = word.upper()
-    elif word.isupper() and not word in capital_exceptions:
+    elif word.isupper() and word not in capital_exceptions:
         final = word.upper()
     elif not word.islower() and not word.isupper() and not word.lower() in word_exceptions:
         final = word

--- a/Contents/Code/PAutils.py
+++ b/Contents/Code/PAutils.py
@@ -225,7 +225,7 @@ def parseTitle(s, siteID):
 
 def parseWord(word, siteID):
     word_exceptions = ['a', 'an', 'of', 'the', 'to', 'and', 'by', 'for', 'on', 'to', 'onto', 'but', 'or', 'nor', 'at', 'with', 'vs.', 'vs']
-    adult_exceptions = ['bbc', 'xxx', 'bbw', 'bf', 'bff']
+    adult_exceptions = ['bbc', 'xxx', 'bbw', 'bf', 'bff', 'bts', 'pov', 'dp', 'gf']
     capital_exceptions = ['A', 'V']
     sitename = PAsearchSites.getSearchSiteName(siteID).replace(' ','')
 

--- a/Contents/Code/PAutils.py
+++ b/Contents/Code/PAutils.py
@@ -197,3 +197,58 @@ def saveRequest(url, req):
     Log('GZip request saved as "%s"' % file_name)
 
     return True
+
+def parseTitle(s):
+    s = re.sub(r'w\/(?!\s)', 'w/ ', s, flags=re.IGNORECASE)
+    s = re.sub(r'\,(?!\s)', ', ', s)
+    word_list = re.split(' ', s)
+
+    firstword = parseWord(word_list[0])
+    if len(firstword) > 1:
+        firstword = firstword[0].capitalize() + firstword[1:]
+    else:
+        firstword = firstword.capitalize()
+
+    final = [firstword]
+
+    for word in word_list[1:]:
+        final.append(parseWord(word))
+
+    output = " ".join(final)
+    output = re.sub(r"\b(?:\.)$", "", output)
+    output = re.sub(r"\.(?=([a-z]))", ". ", output)
+    output = re.sub(r"\s+([.,!\":])", "", output)
+
+    return output
+
+def parseWord(word):
+    word_exceptions = ['a', 'an', 'of', 'the', 'to', 'and', 'by', 'for', 'on', 'to', 'onto', 'but', 'or', 'nor', 'at', 'with', 'vs.', 'vs']
+    adult_exceptions = ['bbc', 'xxx', 'bbw', 'bf', 'bff']
+    capital_exceptions = ['A','V']
+
+    if '-' in word and not '--' in word:
+        word_list = re.split('-', word)
+
+        firstword = parseWord(word_list[0])
+        if len(firstword) > 1:
+            firstword = firstword[0].capitalize() + firstword[1:]
+        else:
+            firstword = firstword.capitalize()
+        nhword = firstword + '-'
+
+        for hword in word_list[1:]:
+            nhword += parseWord(hword)
+            if hword != word_list[-1]:
+                nhword += '-'
+        final = nhword
+    elif word.lower() in adult_exceptions:
+        final = word.upper()
+    elif word.isupper() and not word in capital_exceptions:
+        final = word.upper()
+    elif not word.islower() and not word.isupper() and not word.lower() in word_exceptions:
+        final = word
+    else:
+        word = word.lower()
+        final = word if word in word_exceptions else word.capitalize()
+
+    return final

--- a/Contents/Code/PAutils.py
+++ b/Contents/Code/PAutils.py
@@ -199,12 +199,12 @@ def saveRequest(url, req):
     return True
 
 
-def parseTitle(s):
+def parseTitle(s, siteID):
     s = re.sub(r'w\/(?!\s)', 'w/ ', s, flags=re.IGNORECASE)
     s = re.sub(r'\,(?!\s)', ', ', s)
     word_list = re.split(' ', s)
 
-    firstword = parseWord(word_list[0])
+    firstword = parseWord(word_list[0], siteID)
     if len(firstword) > 1:
         firstword = firstword[0].capitalize() + firstword[1:]
     else:
@@ -213,7 +213,7 @@ def parseTitle(s):
     final = [firstword]
 
     for word in word_list[1:]:
-        final.append(parseWord(word))
+        final.append(parseWord(word, siteID))
 
     output = ' '.join(final)
     output = re.sub(r'\b(?:\.)$', '', output)
@@ -223,15 +223,16 @@ def parseTitle(s):
     return output
 
 
-def parseWord(word):
+def parseWord(word, siteID):
     word_exceptions = ['a', 'an', 'of', 'the', 'to', 'and', 'by', 'for', 'on', 'to', 'onto', 'but', 'or', 'nor', 'at', 'with', 'vs.', 'vs']
     adult_exceptions = ['bbc', 'xxx', 'bbw', 'bf', 'bff']
     capital_exceptions = ['A', 'V']
+    sitename = PAsearchSites.getSearchSiteName(siteID).replace(' ','')
 
     if '-' in word and '--' not in word:
         word_list = re.split('-', word)
 
-        firstword = parseWord(word_list[0])
+        firstword = parseWord(word_list[0], siteID)
         if len(firstword) > 1:
             firstword = firstword[0].capitalize() + firstword[1:]
         else:
@@ -239,7 +240,7 @@ def parseWord(word):
         nhword = firstword + '-'
 
         for hword in word_list[1:]:
-            nhword += parseWord(hword)
+            nhword += parseWord(hword, siteID)
             if hword != word_list[-1]:
                 nhword += '-'
         final = nhword
@@ -247,6 +248,8 @@ def parseWord(word):
         final = word.upper()
     elif word.isupper() and word not in capital_exceptions:
         final = word.upper()
+    elif sitename.lower() == word.lower():
+        final = sitename   
     elif not word.islower() and not word.isupper() and not word.lower() in word_exceptions:
         final = word
     else:

--- a/Contents/Code/siteBangBros.py
+++ b/Contents/Code/siteBangBros.py
@@ -35,7 +35,7 @@ def update(metadata, siteID, movieGenres, movieActors):
     detailsPageElements = HTML.ElementFromString(req.text)
 
     # Title
-    metadata.title = detailsPageElements.xpath('//h1')[0].text_content()
+    metadata.title = PAutils.parseTitle(detailsPageElements.xpath('//h1')[0].text_content())
 
     # Summary
     metadata.summary = detailsPageElements.xpath('//div[@class="vdoDesc"]')[0].text_content().strip()

--- a/Contents/Code/siteBangBros.py
+++ b/Contents/Code/siteBangBros.py
@@ -10,7 +10,7 @@ def search(results, encodedTitle, searchTitle, siteNum, lang, searchDate):
 
         for searchResult in searchResults.xpath('//div[@class="thumbsHolder elipsTxt"]/div[1]/div[@class="echThumb"]'):
             if searchResult.xpath('.//a[contains(@href, "/video")]'):
-                titleNoFormatting = searchResult.xpath('.//a[contains(@href, "/video")]/@title')[0]
+                titleNoFormatting = PAutils.parseTitle(searchResult.xpath('.//a[contains(@href, "/video")]/@title')[0])
                 curID = PAutils.Encode(searchResult.xpath('.//a[contains(@href, "/video")]//@href')[0])
                 subSite = searchResult.xpath('.//span[@class="faTxt"]')[0].text_content().strip()
                 releaseDate = parse(searchResult.xpath('.//span[@class="faTxt"]')[1].text_content().strip()).strftime('%Y-%m-%d')

--- a/Contents/Code/siteBangBros.py
+++ b/Contents/Code/siteBangBros.py
@@ -10,7 +10,7 @@ def search(results, encodedTitle, searchTitle, siteNum, lang, searchDate):
 
         for searchResult in searchResults.xpath('//div[@class="thumbsHolder elipsTxt"]/div[1]/div[@class="echThumb"]'):
             if searchResult.xpath('.//a[contains(@href, "/video")]'):
-                titleNoFormatting = PAutils.parseTitle(searchResult.xpath('.//a[contains(@href, "/video")]/@title')[0])
+                titleNoFormatting = PAutils.parseTitle(searchResult.xpath('.//a[contains(@href, "/video")]/@title')[0], siteNum)
                 curID = PAutils.Encode(searchResult.xpath('.//a[contains(@href, "/video")]//@href')[0])
                 subSite = searchResult.xpath('.//span[@class="faTxt"]')[0].text_content().strip()
                 releaseDate = parse(searchResult.xpath('.//span[@class="faTxt"]')[1].text_content().strip()).strftime('%Y-%m-%d')
@@ -35,7 +35,7 @@ def update(metadata, siteID, movieGenres, movieActors):
     detailsPageElements = HTML.ElementFromString(req.text)
 
     # Title
-    metadata.title = PAutils.parseTitle(detailsPageElements.xpath('//h1')[0].text_content())
+    metadata.title = PAutils.parseTitle(detailsPageElements.xpath('//h1')[0].text_content(), siteID)
 
     # Summary
     metadata.summary = detailsPageElements.xpath('//div[@class="vdoDesc"]')[0].text_content().strip()


### PR DESCRIPTION
### Title Parser Utility
This was specifically created for BangBros because of some of the terrible titles their site returns. The .title() function is severly limited and not tuned to handle specific scenarios. This can also be used for any site since it will take a properly formatted title and return it as is.

I have defined a utility that will handle most cases [that I ran into matching BangBros] where a title is not properly capitalized. 

### All Caps
This is kept in all cases. This is preferable because the capitalization provides emphasis and context.
Examples:
- "ASS"
-  "TITTIES"

### Partial Caps
This is kept in all cases. This is preferable because the capitalization provides emphasis and context.
Examples:
- "ASSets"
- "BangBros"

### Bad Punctuation
Remove spaces before punctuation 
Examples: 
- "ASS !" 
- "Help : I'm Stuck"
- "Hi.I can't put spaces after periods"
- "Or I Put Periods at the End of Titles."

### Exceptions:
- Hyphenated Words: Each word in the sequence should be capitalized (or maintain partial/all caps)
- Word Exceptions: Words that should almost never be capitalized in a title. 
- Adult Exceptions: Adult Abbreviations that should be all caps (There may be more that I haven't come across yet)
- Capital Exceptions: 'A' and 'V' should not be capitalized in the middle of a sentence