### PR TITLE
Fix for NewSensations site redesign

### DIFF
--- a/Contents/Code/PAactors.py
+++ b/Contents/Code/PAactors.py
@@ -223,6 +223,8 @@ class PhoenixActors:
                     newActor = 'Zoe Bloom'
                 elif newActor == 'Shinoda Yuu':
                     newActor = 'Yu Shinoda'
+                elif newActor == 'Polina Maxima' or newActor == 'Venera Maxima':
+                    newActor ='Polina Maxim'
                 elif newActor == 'Viola Bailey’S':
                     newActor = 'Viola Bailey'
                 elif newActor == 'Ornella Morgen':

--- a/Contents/Code/PAactors.py
+++ b/Contents/Code/PAactors.py
@@ -223,7 +223,7 @@ class PhoenixActors:
                     newActor = 'Zoe Bloom'
                 elif newActor == 'Shinoda Yuu':
                     newActor = 'Yu Shinoda'
-                elif newActor == 'Polina Maxima' or newActor == 'Venera Maxima':
+                elif newActor == 'Polina Maxima' or newActor == 'Polina Max' or newActor == 'Venera Maxima':
                     newActor ='Polina Maxim'
                 elif newActor == 'Viola Bailey’S':
                     newActor = 'Viola Bailey'

--- a/Contents/Code/PAactors.py
+++ b/Contents/Code/PAactors.py
@@ -121,6 +121,8 @@ class PhoenixActors:
                     newActor = 'Emma Fantasy'
                 elif newActor == 'Eve Lawrence':
                     newActor = 'Eve Laurence'
+                elif newActor == 'Foxi Di':
+                    newActor = 'Foxy Di'
                 elif newActor == 'Francesca Di Caprio' or newActor == 'Francesca Dicaprio':
                     newActor = 'Francesca DiCaprio'
                 elif newActor == 'Goldie':

--- a/Contents/Code/siteDorcelClub.py
+++ b/Contents/Code/siteDorcelClub.py
@@ -107,9 +107,12 @@ def update(metadata, siteID, movieGenres, movieActors):
 
     # Director
     director = metadata.directors.new()
-    movieDirector = detailsPageElements.xpath('//span[@class="director"]')[0].text_content().replace(
-        'Director :', '').strip()
-    director.name = movieDirector
+    try:
+        movieDirector = detailsPageElements.xpath('//span[@class="director"]')[0].text_content().replace(
+            'Director :', '').strip()
+        director.name = movieDirector
+    except:
+        pass
 
     # Poster
     art = []

--- a/Contents/Code/siteNewSensations.py
+++ b/Contents/Code/siteNewSensations.py
@@ -100,7 +100,7 @@ def update(metadata, siteID, movieGenres, movieActors):
 
         # Posters
         try:
-            art.append(detailsPageElements.xpath('//span[@id="trailer_thumb"]//img/@src')[0])
+            art.append(detailsPageElements.xpath('//span[@id="trailer_thumb"]//img/@src')[0].strip())
         except:
             pass
 

--- a/Contents/Code/siteNewSensations.py
+++ b/Contents/Code/siteNewSensations.py
@@ -128,7 +128,7 @@ def update(metadata, siteID, movieGenres, movieActors):
         # Posters
         try:
             art.append(detailsPageElements.xpath('//span[@id="trailer_thumb"]//img/@src')[0].strip())
-            for imgLink in detailsPageElements.xpath('//div[@class="videoBlock"]//img/@src'):
+            for imgLink in detailsPageElements.xpath('//div[@class="videoBlock"]//img/@src0_3x'):
                 art.append(imgLink.strip())
         except:
             pass

--- a/Contents/Code/siteNewSensations.py
+++ b/Contents/Code/siteNewSensations.py
@@ -20,14 +20,17 @@ def search(results, encodedTitle, searchTitle, siteNum, lang, searchDate):
     for sceneURL in searchResultsURLs:
         req = PAutils.HTTPRequest(sceneURL)
         if req.ok:
-            searchResult = HTML.ElementFromString(req.text)
+            try:
+                searchResult = HTML.ElementFromString(req.text)
 
-            titleNoFormatting = searchResult.xpath('(//div[@class="indScene"] | //div[@class="indSceneDVD"])/h2')[0].text_content().strip()
-            curID = PAutils.Encode(sceneURL)
+                titleNoFormatting = searchResult.xpath('(//div[@class="indScene"] | //div[@class="indSceneDVD"])/h2')[0].text_content().strip()
+                curID = PAutils.Encode(sceneURL)
 
-            score = 100 - Util.LevenshteinDistance(searchTitle.lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchTitle.lower(), titleNoFormatting.lower())
 
-            results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [New Sensations]' % titleNoFormatting, score=score, lang=lang))
+                results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [New Sensations]' % titleNoFormatting, score=score, lang=lang))
+            except:
+                pass
 
     return results
 

--- a/Contents/Code/siteNewSensations.py
+++ b/Contents/Code/siteNewSensations.py
@@ -75,7 +75,7 @@ def update(metadata, siteID, movieGenres, movieActors):
         metadata.year = metadata.originally_available_at.year
 
         # Actors
-        actors = detailsPageElements.xpath('//div[@class="sceneTextLink"]/span[@class="tour_update_models"]/a')
+        actors = detailsPageElements.xpath('//div[@class="sceneTextLink"]//span[@class="tour_update_models"]/a')
         if actors:
             if len(actors) == 3:
                 movieGenres.addGenre('Threesome')
@@ -100,7 +100,7 @@ def update(metadata, siteID, movieGenres, movieActors):
 
         # Posters
         try:
-            art.append(detailsPageElements.xpath('//span[@id="trailer_thumb"]//img[@class="loading"]/@src')[0])
+            art.append(detailsPageElements.xpath('//span[@id="trailer_thumb"]//img/@src')[0])
         except:
             pass
 

--- a/Contents/Code/siteNewSensations.py
+++ b/Contents/Code/siteNewSensations.py
@@ -75,7 +75,7 @@ def update(metadata, siteID, movieGenres, movieActors):
         metadata.year = metadata.originally_available_at.year
 
         # Actors
-        actors = detailsPageElements.xpath('//span[@class="tour_update_models"]/a')
+        actors = detailsPageElements.xpath('//div[@class="sceneTextLink"]/span[@class="tour_update_models"]/a')
         if actors:
             if len(actors) == 3:
                 movieGenres.addGenre('Threesome')

--- a/Contents/Code/siteNewSensations.py
+++ b/Contents/Code/siteNewSensations.py
@@ -22,13 +22,12 @@ def search(results, encodedTitle, searchTitle, siteNum, lang, searchDate):
         if req.ok:
             searchResult = HTML.ElementFromString(req.text)
 
-            titleNoFormatting = searchResult.xpath('(//div[@class="trailerVideos clear"] | //div[@class="dvdSections clear"])/div[1]')[0].text_content().replace('DVDS /', '').strip()
+            titleNoFormatting = searchResult.xpath('(//div[@class="indScene"] | //div[@class="indSceneDVD"])/h2')[0].text_content().strip()
             curID = PAutils.Encode(sceneURL)
-            releaseDate = parse(searchDate).strftime('%Y-%m-%d') if searchDate else ''
 
             score = 100 - Util.LevenshteinDistance(searchTitle.lower(), titleNoFormatting.lower())
 
-            results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [New Sensations]' % titleNoFormatting, score=score, lang=lang))
+            results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [New Sensations]' % titleNoFormatting, score=score, lang=lang))
 
     return results
 

--- a/Contents/Code/siteNewSensations.py
+++ b/Contents/Code/siteNewSensations.py
@@ -94,7 +94,7 @@ def update(metadata, siteID, movieGenres, movieActors):
 
     else:
         # Title
-        title = detailsPageElements.xpath('//div[@class="indSceneDVD"])/h2')[0].text_content().strip()
+        title = detailsPageElements.xpath('//div[@class="indSceneDVD"]/h2')[0].text_content().strip()
         metadata.title = title
 
         # Summary

--- a/Contents/Code/siteNewSensations.py
+++ b/Contents/Code/siteNewSensations.py
@@ -61,8 +61,7 @@ def update(metadata, siteID, movieGenres, movieActors):
         metadata.title = detailsPageElements.xpath('//div[@class="indScene"]/h2')[0].text_content().strip()
 
         # Summary
-        metadata.summary = detailsPageElements.xpath('//div[@class="description"]/p')[0].text_content().strip()
-        Log('Scene Date: %s', metadata.summary)
+        metadata.summary = detailsPageElements.xpath('//div[@class="description"]/p')[0].text_content().replace('Description:', '').strip()
 
         # Tagline and Collection(s)
         metadata.collections.add(PAsearchSites.getSearchSiteName(siteID))
@@ -70,8 +69,7 @@ def update(metadata, siteID, movieGenres, movieActors):
         # No genres for scenes
 
         # Release Date
-        date = detailsPageElements.xpath('//div[@class="sceneDateP"]')[0].text_content().strip()
-        Log('Scene Date: %s', date)
+        date = detailsPageElements.xpath('//div[@class="sceneDateP"]')[0].text_content().split(',')[0].strip()
         date_object = parse(date)
         metadata.originally_available_at = date_object
         metadata.year = metadata.originally_available_at.year


### PR DESCRIPTION
Fix for NewSensations site redesign as mentioned in issue #1101 

Some features removed from the site:
- No genres on scene pages, they only appear in dvds
- No link to dvds from scene pages
- No link to dvd cover from dvd page. (They still exist in [dvd list pages](https://www.newsensations.com/tour_ns/dvds/dvds.html), but I couldn't find a way to use it)