### PR TITLE
Implements basic matching support for melenamariarya.com

### DIFF
--- a/Contents/Code/PAsiteList.py
+++ b/Contents/Code/PAsiteList.py
@@ -148,6 +148,7 @@ import siteSunnyLaneLive
 import networkFAKings
 import networkBangBrosOther
 import sitePutalocura
+import siteMelenaMariaRya
 
 searchSites = {
     0: ('BlackedRaw', 'https://www.blackedraw.com', '/api'),
@@ -1309,6 +1310,7 @@ searchSites = {
     1156: ('Mia Khalifa', 'http://miakhalifa.com/', '/'),
     1157: ('Blacks On Moms', 'http://blacksonmoms.com', '/'),
     1158: ('Filthy Family', 'https://filthyfamily.com', '/'),
+    1159: ('Melena Maria Rya', 'https://www.melenamariarya.com', '/scene/'),
 }
 
 abbreviations = (
@@ -2470,5 +2472,9 @@ def getProviderFromSiteNum(siteNum):
         # Putalocura
         elif siteNum == 1155:
             provider = sitePutalocura
+
+        # Melena Maria Rya
+        elif siteNum == 1159:
+            provider = siteMelenaMariaRya
 
     return provider

--- a/Contents/Code/siteMelenaMariaRya.py
+++ b/Contents/Code/siteMelenaMariaRya.py
@@ -1,0 +1,74 @@
+import PAsearchSites
+import PAgenres
+import PAactors
+import PAutils
+import re
+
+def search(results, encodedTitle, searchTitle, siteNum, lang, searchDate):
+    sceneID = searchTitle.split(' ', 1)[0]
+    try:
+        sceneTitle = searchTitle.split(' ', 1)[1]
+    except:
+        sceneTitle = ''
+
+    sceneURL = PAsearchSites.getSearchSearchURL(siteNum) + sceneID
+    Log(sceneURL)
+    req = PAutils.HTTPRequest(sceneURL)
+    detailsPageElements = HTML.ElementFromString(req.text)
+
+    titleNoFormatting = detailsPageElements.xpath('//title')[0].text_content().split(' - Sex Movies Featuring Melena Maria Rya')[0]
+    titleNoFormatting = re.sub(r'[^A-Za-z0-9\s\-]+', ' ', titleNoFormatting).strip()
+
+    curID = PAutils.Encode(sceneURL)
+    releaseDate = '1900-01-01'
+
+    if sceneTitle:
+        score = 100 - Util.LevenshteinDistance(sceneTitle.lower(), titleNoFormatting.lower())
+    else:
+        score = 90
+
+    results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [MelenaMariaRya]' % (titleNoFormatting), score=score, lang=lang))
+
+    return results
+
+
+def update(metadata, siteNum, movieGenres, movieActors):
+    metadata_id = str(metadata.id).split('|')
+    sceneURL = PAutils.Decode(metadata_id[0])
+    if not sceneURL.startswith('http'):
+        sceneURL = PAsearchSites.getSearchBaseURL(siteNum) + sceneURL
+    req = PAutils.HTTPRequest(sceneURL)
+    detailsPageElements = HTML.ElementFromString(req.text)
+
+    # Title
+    metadata.title = detailsPageElements.xpath('//title')[0].text_content().split(' - Sex Movies Featuring Melena Maria Rya')[0]
+    metadata.title = re.sub('[^A-Za-z0-9\s\-]', ' ', metadata.title).strip()
+    oTitle = metadata.title
+    metadata.title = re.sub(r' with ([A-Z][a-z]+) ([A-Z][a-z]+)', '', metadata.title)
+
+    # Summary
+    metadata.summary = detailsPageElements.xpath('//meta[@name="description"]/@content')[0].strip()
+
+    # Studio
+    metadata.studio = 'MelenaMariaRya'
+
+    # Tagline and Collection(s)
+    metadata.collections.clear()
+    tagline = PAsearchSites.getSearchSiteName(siteNum).strip()
+    metadata.tagline = tagline
+    metadata.collections.add(tagline)
+
+    # Genres
+    movieGenres.clearGenres()
+    movieGenres.addGenre('European Girls')
+
+    # Actors
+    movieActors.clearActors()
+    movieActors.addActor('Melena Maria Rya', '')
+
+    m = re.search(r' with ([A-Z][a-z]+ [A-Z][a-z]+)', oTitle)
+    if m:
+        movieActors.addActor(m.group(1), '')
+
+    return metadata
+

--- a/Contents/Code/siteMelenaMariaRya.py
+++ b/Contents/Code/siteMelenaMariaRya.py
@@ -2,7 +2,7 @@ import PAsearchSites
 import PAgenres
 import PAactors
 import PAutils
-import re
+
 
 def search(results, encodedTitle, searchTitle, siteNum, lang, searchDate):
     sceneID = searchTitle.split(' ', 1)[0]
@@ -12,7 +12,6 @@ def search(results, encodedTitle, searchTitle, siteNum, lang, searchDate):
         sceneTitle = ''
 
     sceneURL = PAsearchSites.getSearchSearchURL(siteNum) + sceneID
-    Log(sceneURL)
     req = PAutils.HTTPRequest(sceneURL)
     detailsPageElements = HTML.ElementFromString(req.text)
 
@@ -20,30 +19,32 @@ def search(results, encodedTitle, searchTitle, siteNum, lang, searchDate):
     titleNoFormatting = re.sub(r'[^A-Za-z0-9\s\-]+', ' ', titleNoFormatting).strip()
 
     curID = PAutils.Encode(sceneURL)
-    releaseDate = '1900-01-01'
+    releaseDate = searchDate if searchDate else ''
 
-    if sceneTitle:
-        score = 100 - Util.LevenshteinDistance(sceneTitle.lower(), titleNoFormatting.lower())
-    else:
-        score = 90
+    score = 100
 
-    results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [MelenaMariaRya]' % (titleNoFormatting), score=score, lang=lang))
+    results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [MelenaMariaRya]' % titleNoFormatting, score=score, lang=lang))
 
     return results
 
 
 def update(metadata, siteNum, movieGenres, movieActors):
     metadata_id = str(metadata.id).split('|')
+
     sceneURL = PAutils.Decode(metadata_id[0])
     if not sceneURL.startswith('http'):
         sceneURL = PAsearchSites.getSearchBaseURL(siteNum) + sceneURL
+
+    sceneDate = None
+    if len(metadata_id) > 2:
+        sceneDate = metadata_id[2]
+
     req = PAutils.HTTPRequest(sceneURL)
     detailsPageElements = HTML.ElementFromString(req.text)
 
     # Title
     metadata.title = detailsPageElements.xpath('//title')[0].text_content().split(' - Sex Movies Featuring Melena Maria Rya')[0]
     metadata.title = re.sub('[^A-Za-z0-9\s\-]', ' ', metadata.title).strip()
-    oTitle = metadata.title
     metadata.title = re.sub(r' with ([A-Z][a-z]+) ([A-Z][a-z]+)', '', metadata.title)
 
     # Summary
@@ -58,17 +59,47 @@ def update(metadata, siteNum, movieGenres, movieActors):
     metadata.tagline = tagline
     metadata.collections.add(tagline)
 
+    # Release Date
+    if sceneDate:
+        date_object = parse(sceneDate)
+        metadata.originally_available_at = date_object
+        metadata.year = metadata.originally_available_at.year
+
     # Genres
     movieGenres.clearGenres()
-    movieGenres.addGenre('European Girls')
+    movieGenres.addGenre('European')
 
     # Actors
     movieActors.clearActors()
     movieActors.addActor('Melena Maria Rya', '')
 
-    m = re.search(r' with ([A-Z][a-z]+ [A-Z][a-z]+)', oTitle)
+    m = re.search(r' with ([A-Z][a-z]+ [A-Z][a-z]+)', metadata.title)
     if m:
         movieActors.addActor(m.group(1), '')
 
-    return metadata
+    # Posters/Background
+    xpaths = []
+    for xpath in xpaths:
+        for img in detailsPageElements.xpath(xpath):
+            art.append(img)
 
+    Log('Artwork found: %d' % len(art))
+    for idx, posterUrl in enumerate(art, 1):
+        if not PAsearchSites.posterAlreadyExists(posterUrl, metadata):
+            # Download image file for analysis
+            try:
+                image = PAutils.HTTPRequest(posterUrl, headers={'Referer': 'http://www.google.com'})
+                im = StringIO(image.content)
+                resized_image = Image.open(im)
+                width, height = resized_image.size
+                # Add the image proxy items to the collection
+                if (width > 1 or height > width) and width < height:
+                    # Item is a poster
+                    metadata.posters[posterUrl] = Proxy.Media(image.content, sort_order=idx)
+                if width > 100 and width > height:
+                    # Item is an art item
+                    metadata.art[posterUrl] = Proxy.Media(image.content, sort_order=idx)
+            except:
+                pass
+
+    return metadata

--- a/docs/sitelist.md
+++ b/docs/sitelist.md
@@ -507,6 +507,7 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
 + #### LustReality | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
 + #### ManyVids | Matching type: *[Exact](./manualsearch.md#exact-match)* - **SceneID, Date Add**
 + #### Meana Wolf | Matching type: *[Limited](./manualsearch.md#limited-search)*
++ #### Melena Maria Rya | Matching type: *[Exact](./manualsearch.md#exact-match)* - **SceneID**
 + #### Melone Challenge | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
 + #### MetArt Network | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
   - ALS Scan

--- a/postprocessing2/PAsearchSites.py
+++ b/postprocessing2/PAsearchSites.py
@@ -987,6 +987,7 @@ searchSites[976] = ("Backroom Casting Couch", "Backroom Casting Couch", "https:/
 searchSites[977] = ("Black Ambush", "Black Ambush", "https://blackambush.com/", "https://blackambush.com/free/girls.php")
 searchSites[978] = ("Exploited College Girls", "Exploited College Girls", "https://exploitedcollegegirls.com/", "https://exploitedcollegegirls.com/free/girls.php?alpha=")
 searchSites[979] = ("Desperate Amateurs", "Desperate Amateurs", "https://desperateamateurs.com/", "https://desperateamateurs.com/fintour/search.php?st=advanced&qall=")
+searchSites[980] = ("Melena Maria Rya", "Melena Maria Rya", "https://www.melenamariarya.com", "https://www.melenamariarya.com/scene/")
 
 
 def getSearchBaseURL(siteID):
@@ -1195,6 +1196,7 @@ def getSearchSettings(filename_title):
         ('^mlib ', 'MilfsLikeItBig '),
         ('^mlt ', 'MomsLickTeens '),
         ('^mmgs ', 'MommysGirl '),
+        ('^mmr ', 'MelenaMariaRya '),
         ('^mmts ', 'MomsTeachSex '),
         ('^mnm ', 'MyNaughtyMassage '),
         ('^mom ', 'MomXXX '),


### PR DESCRIPTION
The source site provides no artwork, no date info, rarely offers a description and has no search facility, so this system really only pulls the title and the occasional summary.

Matching must be done with scene ID, so an example search term of `melenamariarya 6700076` will return data from `melenamariarya.com/scene/6700076/hot-summer`