### PR TITLE
Fix NetworkStrike3 (Blacked, Vixen, Tushy, Deeper...) genre tagging for new scenes

### DIFF
--- a/Contents/Code/networkStrike3.py
+++ b/Contents/Code/networkStrike3.py
@@ -64,14 +64,12 @@ def update(metadata, siteNum, movieGenres, movieActors):
 
     # Genres
     movieGenres.clearGenres()
-    
-    genres = video['categories']
-    for genre in genres:
-        movieGenres.addGenre(genre['name'])
-    
-    genres = video['tags']
-    for genreName in genres:
-        movieGenres.addGenre(genreName)
+
+    for tag in ['categories', 'tags']:
+        for genre in video[tag]:
+            genreName = genre['name']
+
+            movieGenres.addGenre(genreName)
 
     # Actors
     movieActors.clearActors()

--- a/Contents/Code/networkStrike3.py
+++ b/Contents/Code/networkStrike3.py
@@ -64,6 +64,11 @@ def update(metadata, siteNum, movieGenres, movieActors):
 
     # Genres
     movieGenres.clearGenres()
+    
+    genres = video['categories']
+    for genre in genres:
+        movieGenres.addGenre(genre['name'])
+    
     genres = video['tags']
     for genreName in genres:
         movieGenres.addGenre(genreName)


### PR DESCRIPTION
Fix genres tagging for new* scenes from Blacked, Vixen, Tushy...etc

I was not getting genres in the scenes after May-June 2020, seems they have changed the tags keywords.