### PR TITLE
Implements support for Watch4Beauty

### DIFF
--- a/Contents/Code/PAdatabaseActors.py
+++ b/Contents/Code/PAdatabaseActors.py
@@ -1307,6 +1307,11 @@ ActorsReplaceStudios = {
     40: {
         'Natalia Andreeva': ['Natalia A'],
     },
+    41: {
+        'Krystal Boyd': ['Abby'],
+        'Melena Maria Rya': ['Maria'],
+        # TODO: others?
+    }
 }
 
 ActorsStudioIndexes = {
@@ -1351,4 +1356,5 @@ ActorsStudioIndexes = {
     38: ['CzechVR'],
     39: ['Teen Mega World'],
     40: ['Hegre'],
+    41: ['Watch4Beauty'],
 }

--- a/Contents/Code/PAsiteList.py
+++ b/Contents/Code/PAsiteList.py
@@ -1340,6 +1340,7 @@ searchSites = {
     1181: ('Assylum', 'https://www.assylum.com', '/'),
     1182: ('SlaveMouth', 'https://www.slavemouth.com', '/'),
     1183: ('DickDrainers', 'http://dickdrainers.com', '/tour/search.php?query='),
+    1185: ('Watch4Beauty', 'https://www.watch4beauty.com', '/models/'),
 }
 
 abbreviations = (
@@ -1559,6 +1560,7 @@ abbreviations = (
     ('^tspa ', 'TrickySpa '),
     ('^tss ', 'ThatSitcomShow '),
     ('^tuf ', 'TheUpperFloor '),
+    ('^w4b ', 'Watch4Beauty '),
     ('^wa ', 'WhippedAss '),
     ('^wfbg ', 'WeFuckBlackGirls '),
     ('^wkp ', 'Wicked '),
@@ -2525,5 +2527,9 @@ def getProviderFromSiteNum(siteNum):
         # DickDrainers
         elif siteNum == 1183:
             provider = siteDickDrainers
+
+        # Watch4Beauty
+        elif siteNum == 1185:
+            provider = siteWatch4Beauty
 
     return provider

--- a/Contents/Code/siteWatch4Beauty.py
+++ b/Contents/Code/siteWatch4Beauty.py
@@ -1,6 +1,7 @@
 import PAsearchSites
 import PAutils
 
+
 def search(results, encodedTitle, searchTitle, siteNum, lang, searchDate):
     modelStrings = []
 
@@ -34,7 +35,7 @@ def search(results, encodedTitle, searchTitle, siteNum, lang, searchDate):
         modelsJson = modelsReq.json()
         if modelsJson:
             modelsJson = json.loads(modelsReq.text)
-            modelString = modelsJson[0]['Models'][0].get('model_simple_nickname') # only need one at this point
+            modelString = modelsJson[0]['Models'][0].get('model_simple_nickname')  # only need one at this point
 
             scenesReq = PAutils.HTTPRequest('%s/%s/updates' % (w4bApiUrl('model'), modelString))
             scenesJson = scenesReq.json()
@@ -59,6 +60,7 @@ def search(results, encodedTitle, searchTitle, siteNum, lang, searchDate):
             results.Append(MetadataSearchResult(id='%s|%d|%s' % (modelString, siteNum, sceneString), name='%s, %s [Watch4Beauty]' % (sceneName, sceneDateString), score=score, lang=lang))
 
     return results
+
 
 def update(metadata, siteNum, movieGenres, movieActors):
     metadata_id = str(metadata.id).split('|')
@@ -149,9 +151,11 @@ def update(metadata, siteNum, movieGenres, movieActors):
 
     return metadata
 
+
 def w4bApiUrl(type):
     key = '3yAjOB66l2A566U' if type == 'model' else '7Wywy44w9G9Bbtf'
     return 'https://www.watch4beauty.com/api/%s' % key
+
 
 def w4bArtUrl():
     return 'https://s5q3w2t8.ssl.hwcdn.net/production/'

--- a/Contents/Code/siteWatch4Beauty.py
+++ b/Contents/Code/siteWatch4Beauty.py
@@ -1,0 +1,157 @@
+import PAsearchSites
+import PAutils
+
+def search(results, encodedTitle, searchTitle, siteNum, lang, searchDate):
+    modelStrings = []
+
+    # start by attempting to fetch the list of scenes for a model
+    if searchTitle.lower().find('veronica da souza') >= 0:
+        # this is the only 3-word model nickname
+        modelString = 'veronica-da-souza'
+        modelStrings.append(modelString)
+    else:
+        # try the first word or two of the searchTitle as the model name
+        splitWords = searchTitle.lower().split(' ')
+        searchWords = []
+        for i, searchWord in enumerate(splitWords):
+            if i >= 2:
+                break
+            searchWords.append(searchWord)
+            modelString = '-'.join(searchWords)
+            modelStrings.append(modelString)
+
+    for modelString in modelStrings:
+        scenesReq = PAutils.HTTPRequest('%s/%s/updates' % (w4bApiUrl('model'), modelString))
+        scenesJson = scenesReq.json()
+        if scenesJson:
+            break
+
+    if not scenesJson:
+        # no model matches, so try to get the scene info with the searchTitle
+        Log('No model matches, attempting to match scene title')
+
+        modelsReq = PAutils.HTTPRequest('%s/%s/models' % (w4bApiUrl('scene'), searchTitle.replace(' ', '-').lower()))
+        modelsJson = modelsReq.json()
+        if modelsJson:
+            modelsJson = json.loads(modelsReq.text)
+            modelString = modelsJson[0]['Models'][0].get('model_simple_nickname') # only need one at this point
+
+            scenesReq = PAutils.HTTPRequest('%s/%s/updates' % (w4bApiUrl('model'), modelString))
+            scenesJson = scenesReq.json()
+
+    if not scenesJson:
+        Log('Unable to resolve request to a model name, can not continue')
+        return results
+
+    for scene in scenesJson[0]['Issues']:
+        sceneName = scene.get('issue_title')
+        sceneString = scene.get('issue_simple_title')
+        sceneDateTime = scene.get('issue_datetime')
+        sceneDateString = parse(sceneDateTime).strftime('%Y-%m-%d')
+        modelName = modelString.replace('-', ' ').title()
+        # Log('%s in %s, %s' % (modelString, sceneString, sceneDateString))
+
+        if searchDate:
+            if sceneDateString == searchDate:
+                results.Append(MetadataSearchResult(id='%s|%d|%s' % (modelString, siteNum, sceneString), name='%s, %s [Watch4Beauty]' % (sceneName, sceneDateString), score=100, lang=lang))
+        elif searchTitle:
+            score = 100 - Util.LevenshteinDistance(searchTitle.lower(), sceneName.lower())
+            results.Append(MetadataSearchResult(id='%s|%d|%s' % (modelString, siteNum, sceneString), name='%s, %s [Watch4Beauty]' % (sceneName, sceneDateString), score=score, lang=lang))
+
+    return results
+
+def update(metadata, siteNum, movieGenres, movieActors):
+    metadata_id = str(metadata.id).split('|')
+
+    modelString = metadata_id[0]
+    sceneString = metadata_id[2]
+
+    sceneReq = PAutils.HTTPRequest('%s/%s' % (w4bApiUrl('scene'), sceneString))
+    sceneJson = sceneReq.json()
+    if not sceneJson:
+        return
+
+    # Scene object
+    scene = sceneJson[0]
+
+    # Title
+    metadata.title = scene.get('issue_title')
+
+    # Summary
+    metadata.summary = scene.get('issue_text')
+
+    # Studio
+    metadata.studio = 'Watch4Beauty'
+
+    # Director
+    director = metadata.directors.new()
+    director.name = 'MarK'
+
+    # Tagline and Collection(s)
+    metadata.collections.clear()
+    tagline = PAsearchSites.getSearchSiteName(siteNum).strip()
+    metadata.tagline = tagline
+    metadata.collections.add(tagline)
+
+    # Release Date
+    dateObj = parse(scene.get('issue_datetime'))
+    metadata.originally_available_at = dateObj
+    metadata.year = metadata.originally_available_at.year
+
+    # Genres
+    movieGenres.clearGenres()
+    genreText = scene.get('issue_tags')
+    if genreText:
+        for genreName in genreText.split(', '):
+            movieGenres.addGenre(genreName.strip())
+
+    # Actors
+    movieActors.clearActors()
+
+    # Posters
+    artPrefix = w4bArtUrl() + dateObj.strftime('%Y%m%d')
+    art = [
+        artPrefix + '-issue-cover-1280.jpg',
+        artPrefix + '-issue-video-cover-2560.jpg',
+        artPrefix + '-issue-cover-wide-2560.jpg'
+    ]
+
+    modelsReq = PAutils.HTTPRequest('%s/%s/models' % (w4bApiUrl('scene'), sceneString))
+    if modelsReq and not modelsReq.text == '[]' and not modelsReq.text == '':
+        modelsJson = json.loads(modelsReq.text)
+        for model in modelsJson[0]['Models']:
+            modelName = model.get('model_nickname')
+            modelString = model.get('model_simple_nickname')
+            modelPhotoURL = artPrefix + 'model-%s-320.jpg' % modelString
+            movieActors.addActor(modelName, modelPhotoURL)
+
+            art.append(w4bArtUrl() + 'model-%s-wide-2560.jpg' % modelString)
+            art.append(w4bArtUrl() + 'model-%s-1280.jpg' % modelString)
+
+    Log('Artwork found: %d' % len(art))
+    for idx, posterUrl in enumerate(art, 1):
+        if not PAsearchSites.posterAlreadyExists(posterUrl, metadata):
+            # Download image file for analysis
+            try:
+                image = PAutils.HTTPRequest(posterUrl)
+                im = StringIO(image.content)
+                resized_image = Image.open(im)
+                width, height = resized_image.size
+                # Add the image proxy items to the collection
+                if width > 1:
+                    # Item is a poster
+                    metadata.posters[posterUrl] = Proxy.Media(image.content, sort_order=idx)
+                if width > 100:
+                    # Item is an art item
+                    metadata.art[posterUrl] = Proxy.Media(image.content, sort_order=idx)
+            except:
+                pass
+
+    return metadata
+
+def w4bApiUrl(type):
+    key = '3yAjOB66l2A566U' if type == 'model' else '7Wywy44w9G9Bbtf'
+    return 'https://www.watch4beauty.com/api/%s' % key
+
+def w4bArtUrl():
+    return 'https://s5q3w2t8.ssl.hwcdn.net/production/'

--- a/docs/sitelist.md
+++ b/docs/sitelist.md
@@ -1170,6 +1170,7 @@ The above is a reference list. Please see [the manualsearch doc](./manualsearch.
 + #### WankzVR Network | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
   - MilfVR
   - WankzVR
++ #### Watch4Beauty | Matching type: *[Limited](./manualsearch.md#enhanced-search)* - ** Title or Actor Name, Date Add
 + #### We Are Hairy | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
 + #### Why Not Bi | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*
 + #### Wicked | Matching type: *[Enhanced](./manualsearch.md#enhanced-search)*

--- a/postprocessing2/PAsearchSites.py
+++ b/postprocessing2/PAsearchSites.py
@@ -988,7 +988,7 @@ searchSites[977] = ("Black Ambush", "Black Ambush", "https://blackambush.com/", 
 searchSites[978] = ("Exploited College Girls", "Exploited College Girls", "https://exploitedcollegegirls.com/", "https://exploitedcollegegirls.com/free/girls.php?alpha=")
 searchSites[979] = ("Desperate Amateurs", "Desperate Amateurs", "https://desperateamateurs.com/", "https://desperateamateurs.com/fintour/search.php?st=advanced&qall=")
 searchSites[980] = ("Melena Maria Rya", "Melena Maria Rya", "https://www.melenamariarya.com", "https://www.melenamariarya.com/scene/")
-
+searchSites[982] = ("Watch4Beauty", "Watch4Beauty", "https://www.watch4beauty.com", "https://www.watch4beauty.com/updates/")
 
 def getSearchBaseURL(siteID):
     return searchSites[siteID][2]
@@ -1268,6 +1268,7 @@ def getSearchSettings(filename_title):
         ('^tspa ', 'TrickySpa '),
         ('^tss ', 'ThatSitcomShow '),
         ('^tuf ', 'TheUpperFloor '),
+        ('^w4b ', 'Watch4Beauty '),
         ('^wa ', 'WhippedAss '),
         ('^wfbg ', 'WeFuckBlackGirls '),
         ('^wkp ', 'Wicked '),


### PR DESCRIPTION
Allows rich content fetching with relatively robust searching considering that the site itself offers no scene search facility.

1. Attempt to use the searchTitle to match a model name and load the JSON list of scenes for that model
2. If no model name can be identified, attempt to load the JSON scene info for the searchTitle and if this succeeds, grab the model info and load the JSON list of scenes for that model
3. Loop through the available scenes, matching the date added if provided, or attempting to match against the remainder of the searchTitle

Example search strings to match `watch4beauty.com/updates/welcome-back`:

* `watch4beauty 2020 01 15 maria welcome back`
* `watch4beauty 2020 01 15 maria`
* `watch4beauty 2020 01 15 welcome back`
* `watch4beauty maria welcome back`
* `watch4beauty maria`
* `watch4beauty welcome back`