### PR TITLE
Refactor `search` argument to be an instance of class `SearchData` 

### DIFF
--- a/Contents/Code/PAsearchSites.py
+++ b/Contents/Code/PAsearchSites.py
@@ -61,6 +61,7 @@ def getSearchSettings(mediaTitle):
 
     result = {
         'siteNum': None,
+        'siteName': None,
         'searchTitle': None,
         'searchDate': None,
     }
@@ -117,6 +118,7 @@ def getSearchSettings(mediaTitle):
         searchTitle = searchTitle[0].upper() + searchTitle[1:]
 
         result['siteNum'] = siteNum
+        result['siteName'] = site
         result['searchTitle'] = searchTitle
         result['searchDate'] = searchDate
 

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -70,7 +70,7 @@ class PhoenixAdultAgent(Agent.Movies):
             searchSettings = PAsearchSites.getSearchSettings(newTitle)
 
             if searchSettings['siteNum'] is not None and searchSettings['searchTitle'].lower() == PAsearchSites.getSearchSiteName(searchSettings['siteNum']).lower():
-                newTitle = '%s %s' % (siteName, title)
+                newTitle = '%s %s' % (newTitle, title)
                 Log('***MEDIA TITLE [from directory + media.name]*** %s' % newTitle)
                 searchSettings = PAsearchSites.getSearchSettings(newTitle)
 

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -52,8 +52,9 @@ class PhoenixAdultAgent(Agent.Movies):
 
         title = getSearchTitle(title)
 
-        Log('*** MEDIA TITLE [from media.name] *** %s' % title)
+        Log('***MEDIA TITLE [from media.name]*** %s' % title)
         searchSettings = PAsearchSites.getSearchSettings(title)
+        Log(searchSettings)
 
         filepath = None
         filename = None
@@ -65,12 +66,12 @@ class PhoenixAdultAgent(Agent.Movies):
             directory = str(os.path.split(os.path.dirname(filepath))[1])
 
             newTitle = getSearchTitle(directory)
-            Log('*** MEDIA TITLE [from directory] *** %s' % newTitle)
+            Log('***MEDIA TITLE [from directory]*** %s' % newTitle)
             searchSettings = PAsearchSites.getSearchSettings(newTitle)
 
             if searchSettings['siteNum'] is not None and searchSettings['searchTitle'].lower() == PAsearchSites.getSearchSiteName(searchSettings['siteNum']).lower():
                 newTitle = '%s %s' % (siteName, title)
-                Log('*** MEDIA TITLE [from directory + media.name] *** %s' % newTitle)
+                Log('***MEDIA TITLE [from directory + media.name]*** %s' % newTitle)
                 searchSettings = PAsearchSites.getSearchSettings(newTitle)
 
         siteNum = searchSettings['siteNum']

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -81,6 +81,7 @@ class PhoenixAdultAgent(Agent.Movies):
 
             provider = PAsiteList.getProviderFromSiteNum(siteNum)
             if provider is not None:
+                Log('Provider: %s' % provider)
                 provider.search(results, lang, siteNum, search)
 
         results.Sort('score', descending=True)

--- a/Contents/Code/addActors.py
+++ b/Contents/Code/addActors.py
@@ -1,8 +1,8 @@
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    parse_siteName = search['title'].rsplit(' at ', 1)
+def search(results, lang, siteNum, searchData):
+    parse_siteName = searchData.title.rsplit(' at ', 1)
     if len(parse_siteName) > 1:
         siteName = parse_siteName[1].strip()
     else:
@@ -21,8 +21,8 @@ def search(results, lang, siteNum, search):
     displayName = ', '.join(actorsFormatted)
     curID = PAutils.Encode(displayName)
 
-    if search['date']:
-        releaseDate = parse(search['date']).strftime('%Y-%m-%d')
+    if searchData.date:
+        releaseDate = searchData.dateFormat()
     else:
         releaseDate = ''
 

--- a/Contents/Code/network1service.py
+++ b/Contents/Code/network1service.py
@@ -26,23 +26,23 @@ def get_Token(siteNum):
     return token
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     token = get_Token(siteNum)
     headers = {
         'Instance': token,
     }
 
     sceneID = None
-    splited = search['title'].split()
-    if unicode(splited[0], 'UTF-8').isdigit():
-        sceneID = splited[0]
-        search['title'] = search['title'].replace(sceneID, '', 1).strip()
+    parts = searchData.title.split()
+    if unicode(parts[0], 'UTF-8').isdigit():
+        sceneID = parts[0]
+        searchData.title = searchData.title.replace(sceneID, '', 1).strip()
 
     for sceneType in ['scene', 'movie', 'serie', 'trailer']:
-        if sceneID and not search['title']:
+        if sceneID and not searchData.title:
             url = PAsearchSites.getSearchSearchURL(siteNum) + '/v2/releases?type=%s&id=%s' % (sceneType, sceneID)
         else:
-            url = PAsearchSites.getSearchSearchURL(siteNum) + '/v2/releases?type=%s&search=%s' % (sceneType, search['encoded'])
+            url = PAsearchSites.getSearchSearchURL(siteNum) + '/v2/releases?type=%s&search=%s' % (sceneType, searchData.encoded)
 
         req = PAutils.HTTPRequest(url, headers=headers)
         if req:
@@ -59,10 +59,10 @@ def search(results, lang, siteNum, search):
 
                 if sceneID:
                     score = 100 - Util.LevenshteinDistance(sceneID, curID)
-                elif search['date']:
-                    score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+                elif searchData.date:
+                    score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
                 else:
-                    score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                    score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
                 if sceneType == 'trailer':
                     titleNoFormatting = '[%s] %s' % (sceneType.capitalize(), titleNoFormatting)

--- a/Contents/Code/network5Kporn.py
+++ b/Contents/Code/network5Kporn.py
@@ -2,16 +2,16 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     cookies = {'nats': 'MC4wLjMuNTguMC4wLjAuMC4w'}
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'], cookies=cookies)
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded, cookies=cookies)
     searchResults = HTML.ElementFromString(req.json()['html'])
     for sceneURL in searchResults.xpath('//div[@class="ep"]'):
         titleNoFormatting = searchResults.xpath('.//h3[@class="ep-title"]')[0].text_content().strip()
         sceneURL = searchResults.xpath('.//a/@href')[0]
         curID = PAutils.Encode(sceneURL)
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 

--- a/Contents/Code/networkAbbyWinters.py
+++ b/Contents/Code/networkAbbyWinters.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     searchResults = []
 
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         sceneURL = sceneURL.replace('/cn/', '/').replace('/de/', '/').replace('/jp/', '/').replace('/ja/', '/').replace('/en/', '/')
         if '/nude_girl/' not in sceneURL and '/shoots/' not in sceneURL and '/fetish/' not in sceneURL and '/updates/' not in sceneURL and sceneURL not in searchResults:
@@ -35,13 +35,13 @@ def search(results, lang, siteNum, search):
         if date:
             releaseDate = parse(date).strftime('%Y-%m-%d')
         else:
-            releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+            releaseDate = searchData.dateFormat() if searchData.date else ''
         displayDate = releaseDate if date else ''
 
-        if search['date'] and displayDate:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date and displayDate:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [Abby Winters/%s] %s' % (titleNoFormatting, subSite, displayDate), score=score, lang=lang))
 

--- a/Contents/Code/networkBadoinkVR.py
+++ b/Contents/Code/networkBadoinkVR.py
@@ -2,12 +2,12 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     sceneID = None
-    splited = search['title'].split()
-    if unicode(splited[0], 'utf8').isdigit():
-        sceneID = splited[0]
-        search['title'] = search['title'].replace(sceneID, '', 1).strip()
+    parts = searchData.title.split()
+    if unicode(parts[0], 'utf8').isdigit():
+        sceneID = parts[0]
+        searchData.title = searchData.title.replace(sceneID, '', 1).strip()
         req = PAutils.HTTPRequest(PAsearchSites.getSearchBaseURL(siteNum) + '/vrpornvideo/' + sceneID)
         searchResults = HTML.ElementFromString(req.text)
         titleNoFormatting = searchResults.xpath('//h1[contains(@class, "video-title")]')[0].text_content()
@@ -22,7 +22,7 @@ def search(results, lang, siteNum, search):
         score = 100
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='[%s] %s in %s %s' % (PAsearchSites.getSearchSiteName(siteNum), girlName, titleNoFormatting, releaseDate), score=score, lang=lang))
     else:
-        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
         searchResults = HTML.ElementFromString(req.text)
         for searchResult in searchResults.xpath('//div[@class="tile-grid-item"]'):
             data = searchResult.xpath('.//a[contains(@class, "video-card-title")]')[0]
@@ -33,10 +33,10 @@ def search(results, lang, siteNum, search):
             if date:
                 releaseDate = parse(date[0]).strftime('%Y-%m-%d')
             girlName = searchResult.xpath('.//a[@class="video-card-link"]')[0].text_content()
-            if search['date'] and releaseDate:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date and releaseDate:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='[%s] %s in %s %s' % (PAsearchSites.getSearchSiteName(siteNum), girlName, titleNoFormatting, releaseDate), score=score, lang=lang))
 
     return results

--- a/Contents/Code/networkBang.py
+++ b/Contents/Code/networkBang.py
@@ -13,8 +13,8 @@ def getDataFromAPI(url, req_type, query):
     return data
 
 
-def search(results, lang, siteNum, search):
-    searchResults = getDataFromAPI(PAsearchSites.getSearchSearchURL(siteNum), 'name', search['title'])['hits']['hits']
+def search(results, lang, siteNum, searchData):
+    searchResults = getDataFromAPI(PAsearchSites.getSearchSearchURL(siteNum), 'name', searchData.title)['hits']['hits']
     for searchResult in searchResults:
         searchResult = searchResult['_source']
         titleNoFormatting = searchResult['name']
@@ -23,10 +23,10 @@ def search(results, lang, siteNum, search):
         curID = searchResult['identifier']
         releaseDate = parse(searchResult['releaseDate']).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='[%s] %s' % (seriesScene.title() if seriesScene else studioScene, titleNoFormatting), score=score, lang=lang))
 

--- a/Contents/Code/networkBangBros.py
+++ b/Contents/Code/networkBangBros.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     for searchPageNum in range(1, 3):
-        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'] + "/" + str(searchPageNum))
+        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded + "/" + str(searchPageNum))
         searchResults = HTML.ElementFromString(req.text)
 
         for searchResult in searchResults.xpath('//div[@class="thumbsHolder elipsTxt"]/div[1]/div[@class="echThumb"]'):
@@ -14,10 +14,10 @@ def search(results, lang, siteNum, search):
                 subSite = searchResult.xpath('.//span[@class="faTxt"]')[0].text_content().strip()
                 releaseDate = parse(searchResult.xpath('.//span[@class="faTxt"]')[1].text_content().strip()).strftime('%Y-%m-%d')
 
-                if search['date']:
-                    score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+                if searchData.date:
+                    score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
                 else:
-                    score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                    score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
                 results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [BangBros/%s] %s' % (titleNoFormatting, subSite, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/networkBangBrosOther.py
+++ b/Contents/Code/networkBangBrosOther.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     searchResults = []
 
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         sceneURL = sceneURL.split('?')[0]
         if ('com/video' in sceneURL or 'com/player' in sceneURL) and 'mobile' not in sceneURL and sceneURL not in searchResults:
@@ -27,15 +27,15 @@ def search(results, lang, siteNum, search):
             if date:
                 releaseDate = parse(date).strftime('%Y-%m-%d')
             else:
-                releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+                releaseDate = searchData.dateFormat() if searchData.date else ''
             displayDate = releaseDate if date else ''
 
             subSite = detailsPageElements.xpath('//script[@type="text/javascript"][contains(.,"siteName")]')[0].text_content().split('siteName = \'')[-1].split('\'')[0].strip()
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, displayDate), name='%s [BangBros/%s] %s' % (titleNoFormatting, subSite, displayDate), score=score, lang=lang))
         except:

--- a/Contents/Code/networkBellaPass.py
+++ b/Contents/Code/networkBellaPass.py
@@ -2,14 +2,14 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[contains(@class, "item-video")]'):
         titleNoFormatting = searchResult.xpath('./div[1]/a/@title')[0].strip()
         curID = PAutils.Encode('http:' + searchResult.xpath('./div[1]/a/@href')[0])
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 

--- a/Contents/Code/networkCherryPimps.py
+++ b/Contents/Code/networkCherryPimps.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].replace(' ', '+')
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.replace(' ', '+')
     for searchPageNum in range(1, 3):
-        url = PAsearchSites.getSearchSearchURL(siteNum) + '%s&page=%d' % (search['encoded'], searchPageNum)
+        url = PAsearchSites.getSearchSearchURL(siteNum) + '%s&page=%d' % (searchData.encoded, searchPageNum)
         req = PAutils.HTTPRequest(url)
         searchResults = HTML.ElementFromString(req.text)
         for searchResult in searchResults.xpath('//div[contains(@class, "video-thumb") or contains(@class, "item-video")]'):
@@ -23,10 +23,10 @@ def search(results, lang, siteNum, search):
                 actorNames.append(actorName)
             actorNames = ', '.join(actorNames)
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s in %s [CherryPimps/%s] %s' % (actorNames, titleNoFormatting, subSite, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/networkCzechAV.py
+++ b/Contents/Code/networkCzechAV.py
@@ -2,16 +2,16 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="episode__title"]'):
         titleNoFormatting = searchResult.xpath('./a/h2')[0].text_content().strip()
         curID = PAutils.Encode(searchResult.xpath('./a/@href')[0])
         subSite = searchResult.xpath('//head/title')[0].text_content().strip()
-        releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+        releaseDate = searchData.dateFormat() if searchData.date else ''
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [CzechAV/%s]' % (titleNoFormatting, subSite), score=score, lang=lang))
 

--- a/Contents/Code/networkCzechVR.py
+++ b/Contents/Code/networkCzechVR.py
@@ -2,14 +2,14 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     sceneID = None
-    splited = search['title'].split()
-    if unicode(splited[0], 'utf8').isdigit():
-        sceneID = splited[0]
-        search['title'] = search['title'].replace(sceneID, '', 1).strip()
-    search['encoded'] = search['title'].replace(' ', '-')
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+    parts = searchData.title.split()
+    if unicode(parts[0], 'utf8').isdigit():
+        sceneID = parts[0]
+        searchData.title = searchData.title.replace(sceneID, '', 1).strip()
+    searchData.encoded = searchData.title.replace(' ', '-')
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[contains(@class,"postTag")]'):
         titleNoFormatting = searchResult.xpath('.//div[@class="nazev"]//h2//a')[0].text_content()
@@ -26,10 +26,10 @@ def search(results, lang, siteNum, search):
         actorsPrint = ', '.join(actorList)
         if sceneID:
             score = 100 - Util.LevenshteinDistance(sceneID, curSceneID)
-        elif search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        elif searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s in %s [%s] %s' % (actorsPrint, titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/networkDDFNetwork.py
+++ b/Contents/Code/networkDDFNetwork.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    sceneID = search['title'].split(' ', 1)[0]
+def search(results, lang, siteNum, searchData):
+    sceneID = searchData.title.split(' ', 1)[0]
     if unicode(sceneID, 'UTF-8').isdigit():
-        search['title'] = search['title'].replace(sceneID, '', 1).strip()
+        searchData.title = searchData.title.replace(sceneID, '', 1).strip()
     else:
         sceneID = None
 
@@ -19,8 +19,8 @@ def search(results, lang, siteNum, search):
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name=titleNoFormatting, score=100, lang=lang))
     else:
-        search['encoded'] = search['title'].replace(' ', '+')
-        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+        searchData.encoded = searchData.title.replace(' ', '+')
+        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
         searchResults = HTML.ElementFromString(req.text)
         for searchResult in searchResults.xpath('//div[@id="content"]//div[contains(@class, "card-body")]'):
             titleNoFormatting = searchResult.xpath('.//a/@title')[0]
@@ -35,10 +35,10 @@ def search(results, lang, siteNum, search):
             sceneCover = PAutils.Encode(sceneCoverURL)
             curID = PAutils.Encode(url)
 
-            if search['date'] and releaseDate:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date and releaseDate:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, sceneCover), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/networkDerangedDollars.py
+++ b/Contents/Code/networkDerangedDollars.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     searchResults = []
 
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         if '/session/' in sceneURL not in searchResults:
             searchResults.append(sceneURL)
@@ -22,13 +22,13 @@ def search(results, lang, siteNum, search):
         if date:
             releaseDate = parse(date).strftime('%Y-%m-%d')
         else:
-            releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+            releaseDate = searchData.dateFormat() if searchData.date else ''
         displayDate = releaseDate if date else ''
 
-        if search['date'] and displayDate:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date and displayDate:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, subSite, displayDate), score=score, lang=lang))
 

--- a/Contents/Code/networkDirtyHardDrive.py
+++ b/Contents/Code/networkDirtyHardDrive.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     searchResults = []
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         if ('/tour1/' in sceneURL and sceneURL.endswith('.html') and sceneURL not in searchResults):
             searchResults.append(sceneURL)
@@ -15,9 +15,9 @@ def search(results, lang, siteNum, search):
 
         curID = PAutils.Encode(sceneURL)
         titleNoFormatting = detailsPageElements.xpath('//h1')[0].text_content().strip()
-        releaseDate = search['date'] if search['date'] else ''
+        releaseDate = searchData.date if searchData.date else ''
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 

--- a/Contents/Code/networkDogfart.py
+++ b/Contents/Code/networkDogfart.py
@@ -2,15 +2,15 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].replace(' a ', ' ')
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.replace(' a ', ' ')
 
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//a[contains(@class, "thumbnail")]'):
         titleNoFormatting = searchResult.xpath('.//h3[@class="scene-title"]')[0].text_content().strip()
         curID = PAutils.Encode(searchResult.get('href').split('?')[0])
-        releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+        releaseDate = searchData.dateFormat() if searchData.date else ''
         fullSubSite = searchResult.xpath('.//div/p[@class="help-block"]')[0].text_content().strip()
 
         if 'BehindTheScenes' in fullSubSite and 'BTS' not in titleNoFormatting:
@@ -18,9 +18,9 @@ def search(results, lang, siteNum, search):
         subSite = fullSubSite.split('.com')[0]
 
         if subSite == PAsearchSites.getSearchSiteName(siteNum):
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
         else:
-            score = 60 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 60 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [Dogfart/%s]' % (titleNoFormatting, subSite), score=score, lang=lang))
 

--- a/Contents/Code/networkEvolvedFights.py
+++ b/Contents/Code/networkEvolvedFights.py
@@ -2,11 +2,11 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    directURL = PAsearchSites.getSearchSearchURL(siteNum) + search['title'].replace(' ', '-').lower() + '.html'
+def search(results, lang, siteNum, searchData):
+    directURL = PAsearchSites.getSearchSearchURL(siteNum) + searchData.title.replace(' ', '-').lower() + '.html'
 
     searchResults = [directURL]
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         if ('/updates/' in sceneURL and sceneURL not in searchResults):
             searchResults.append(sceneURL)
@@ -21,10 +21,10 @@ def search(results, lang, siteNum, search):
             date = detailsPageElements.xpath('//span[(contains(@class, "update_date"))]')[0].text_content().strip()
             releaseDate = datetime.strptime(date, '%m/%d/%Y').strftime('%Y-%m-%d')
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 

--- a/Contents/Code/networkExploitedX.py
+++ b/Contents/Code/networkExploitedX.py
@@ -2,19 +2,19 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    splited = search['title'].split()
+def search(results, lang, siteNum, searchData):
+    parts = searchData.title.split()
     girlID = None
     sceneID = None
 
-    if unicode(splited[0], 'UTF-8').isdigit():
-        girlID = splited[0]
-        search['title'] = search['title'].replace(girlID, '', 1)
+    if unicode(parts[0], 'UTF-8').isdigit():
+        girlID = parts[0]
+        searchData.title = searchData.title.replace(girlID, '', 1)
 
-    if len(splited) > 1 and unicode(splited[1], 'UTF-8').isdigit():
-        sceneID = splited[1]
-        search['title'] = search['title'].replace(sceneID, '', 1)
-    search['title'] = search['title'].strip()
+    if len(parts) > 1 and unicode(parts[1], 'UTF-8').isdigit():
+        sceneID = parts[1]
+        searchData.title = searchData.title.replace(sceneID, '', 1)
+    searchData.title = searchData.title.strip()
 
     searchResults = []
     if girlID and sceneID:
@@ -22,7 +22,7 @@ def search(results, lang, siteNum, search):
     elif girlID and not sceneID:
         searchResults.append(PAsearchSites.getSearchBaseURL(siteNum) + '/free/girl/%s/ecg' % (girlID))
 
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         if ('/free/girl/' in sceneURL) or ('/free/scene/' in sceneURL) and sceneURL not in searchResults:
             searchResults.append(sceneURL)
@@ -39,23 +39,23 @@ def search(results, lang, siteNum, search):
                 except:
                     pass
                 if not releaseDate:
-                    releaseDate = search['date'] if search['date'] else ''
+                    releaseDate = searchData.date if searchData.date else ''
 
                 sceneURL = PAsearchSites.getSearchBaseURL(siteNum) + searchResult.xpath('./div[@class="text-center buttons"]/a/@href')[0].strip()
                 curID = PAutils.Encode(sceneURL)
 
-                if search['date']:
-                    score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+                if searchData.date:
+                    score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
                 else:
-                    score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                    score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
                 results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
         else:
             curID = PAutils.Encode(sceneURL)
-            releaseDate = search['date'] if search['date'] else ''
+            releaseDate = searchData.date if searchData.date else ''
             titleNoFormatting = HTMLResponse.xpath('//h3/text()[1]')[0].strip()
 
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/networkFAKings.py
+++ b/Contents/Code/networkFAKings.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].replace(' ', '-')
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.replace(' ', '-')
 
-    searchURL = '%s%s' % (PAsearchSites.getSearchSearchURL(siteNum), search['encoded'])
+    searchURL = '%s%s' % (PAsearchSites.getSearchSearchURL(siteNum), searchData.encoded)
     req = PAutils.HTTPRequest(searchURL)
     searchPageElements = HTML.ElementFromString(req.text)
 
@@ -21,17 +21,17 @@ def search(results, lang, siteNum, search):
         if date:
             releaseDate = parse(date).strftime('%Y-%m-%d')
         else:
-            releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+            releaseDate = searchData.dateFormat() if searchData.date else ''
         displayDate = releaseDate if date else ''
 
-        if search['date'] and displayDate:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date and displayDate:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [FAKings/%s] %s' % (titleNoFormatting[:20] + '...', subSite, displayDate), score=score, lang=lang))
 
-    searchURL = '%s%s' % (PAsearchSites.getSearchSearchURL(siteNum).replace('/en', ''), search['encoded'])
+    searchURL = '%s%s' % (PAsearchSites.getSearchSearchURL(siteNum).replace('/en', ''), searchData.encoded)
     req = PAutils.HTTPRequest(searchURL)
     searchPageElements = HTML.ElementFromString(req.text)
 
@@ -47,13 +47,13 @@ def search(results, lang, siteNum, search):
         if date:
             releaseDate = parse(date).strftime('%Y-%m-%d')
         else:
-            releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+            releaseDate = searchData.dateFormat() if searchData.date else ''
         displayDate = releaseDate if date else ''
 
-        if search['date'] and displayDate:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date and displayDate:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [FAKings/%s] %s' % (titleNoFormatting[:20] + '...', subSite, displayDate), score=score, lang=lang))
 

--- a/Contents/Code/networkFTV.py
+++ b/Contents/Code/networkFTV.py
@@ -2,21 +2,20 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     sceneID = None
-    splited = search['title'].split()
+    parts = searchData.title.split()
     searchResults = []
 
-    if unicode(splited[0], 'UTF-8').isdigit():
-        sceneID = splited[0]
-        search['title'] = search['title'].replace(sceneID, '', 1).strip()
+    if unicode(parts[0], 'UTF-8').isdigit():
+        sceneID = parts[0]
+        searchData.title = searchData.title.replace(sceneID, '', 1).strip()
         directURL = PAsearchSites.getSearchSearchURL(siteNum) + sceneID + '.html'
 
         searchResults.append(directURL)
 
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
-        sceneURL = sceneURL.replace('://www.', '://')
         if ('/update/' in sceneURL) and sceneURL not in searchResults:
             searchResults.append(sceneURL)
 
@@ -32,10 +31,10 @@ def search(results, lang, siteNum, search):
             date = titleDate[-1].replace('!', '').strip()
             releaseDate = parse(date).strftime('%Y-%m-%d')
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 
@@ -117,7 +116,7 @@ def update(metadata, siteNum, movieGenres, movieActors):
     googleResults = PAutils.getFromGoogleSearch(' '.join(actors).strip(), siteNum)
     for photoURL in googleResults:
         for scene in scenes:
-            if ('galleries' in photoURL or 'preview' in photoURL) and scene in photoURL:
+            if ('galleries' in photoURL or 'preview' in photoURL) and (scene in photoURL or scene == 'none'):
                 req = PAutils.HTTPRequest(photoURL)
                 photoPageElements = HTML.ElementFromString(req.text)
                 for xpath in xpaths:
@@ -164,6 +163,6 @@ def photoLookup(sceneID):
     elif sceneID == 1573 or sceneID == 283:
         scenes = []
     else:
-        scenes = []
+        scenes = ['none']
 
     return scenes

--- a/Contents/Code/networkFemdomEmpire.py
+++ b/Contents/Code/networkFemdomEmpire.py
@@ -2,25 +2,25 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     # Advanced Search
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[contains(@class, "item-info")]'):
         titleNoFormatting = searchResult.xpath('.//a')[0].text_content().strip()
         curID = PAutils.Encode(searchResult.xpath('.//a/@href')[0])
         releaseDate = parse(searchResult.xpath('.//span[@class="date"]')[0].text_content().strip()).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [Femdom Empire] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 
     # Difficult Scenes
-    if search['title'] in manualMatch:
-        item = manualMatch[search['title']]
+    if searchData.title in manualMatch:
+        item = manualMatch[searchData.title]
         curID = PAutils.Encode(item['curID'])
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name=item['name'], score=101, lang=lang))
@@ -30,7 +30,7 @@ def search(results, lang, siteNum, search):
 
     # Standard Search
     else:
-        req = PAutils.HTTPRequest(PAsearchSites.getSearchBaseURL(siteNum) + '/tour/search.php?query=' + search['encoded'])
+        req = PAutils.HTTPRequest(PAsearchSites.getSearchBaseURL(siteNum) + '/tour/search.php?query=' + searchData.encoded)
         searchResults = HTML.ElementFromString(req.text)
         for searchResult in searchResults.xpath('//div[contains(@class, "item-info")]'):
             titleNoFormatting = searchResult.xpath('.//a')[0].text_content().strip()
@@ -38,10 +38,10 @@ def search(results, lang, siteNum, search):
             curID = PAutils.Encode(scenePage)
             releaseDate = parse(searchResult.xpath('.//span[@class="date"]')[0].text_content().strip()).strftime('%Y-%m-%d')
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [Femdom Empire] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/networkFuelVirtual.py
+++ b/Contents/Code/networkFuelVirtual.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@align="left"]'):
         titleNoFormatting = searchResult.xpath('.//td[@valign="top"][2]/a')[0].text_content().strip()
@@ -12,10 +12,10 @@ def search(results, lang, siteNum, search):
         date = searchResult.xpath('.//span[@class="date"]')[0].text_content().replace('Added', '').strip()
         releaseDate = parse(date).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [FuelVirtual/%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/networkFullPornNetwork.py
+++ b/Contents/Code/networkFullPornNetwork.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     searchResultsURLs = []
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
 
     for sceneURL in googleResults:
         if sceneURL not in searchResultsURLs:
@@ -25,22 +25,22 @@ def search(results, lang, siteNum, search):
         detailsPageElements = HTML.ElementFromString(req.text)
         curID = PAutils.Encode(url)
         titleNoFormatting = detailsPageElements.xpath('//h4')[0].text_content().strip()
-        releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+        releaseDate = searchData.dateFormat() if searchData.date else ''
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [FPN/%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 
-    search['encoded'] = search['title'].replace(' ', '_')
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+    searchData.encoded = searchData.title.replace(' ', '_')
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[contains(@class, "section-updates")]'):
         curID = PAutils.Encode(searchResult.xpath('.//a/@href')[0])
         titleNoFormatting = searchResult.xpath('.//div[contains(@class, "scene-info")]//a')[0].text_content().strip()
         poster = searchResult.xpath('.//img/@src')[0]
-        releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+        releaseDate = searchData.dateFormat() if searchData.date else ''
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s|%s' % (curID, siteNum, releaseDate, poster), name='%s [FPN/%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/networkGammaEnt.py
+++ b/Contents/Code/networkGammaEnt.py
@@ -2,7 +2,7 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     networkscene = True
     networkscenepages = True
     networkdvd = True
@@ -83,9 +83,9 @@ def search(results, lang, siteNum, search):
         # Result next page
         resultsecond = []
 
-        # searchResults = HTML.ElementFromURL(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'] + "?query=" + search['encoded'])
-        search['encoded'] = search['encoded'].replace("%27", "").replace("%3F", "").replace("%2C", "")  # Remove troublesome punctuation (, . ?)
-        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + network_sep_scene_prev + search['encoded'] + network_sep_scene)
+        # searchResults = HTML.ElementFromURL(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded + "?query=" + searchData.encoded)
+        searchData.encoded = searchData.encoded.replace("%27", "").replace("%3F", "").replace("%2C", "")  # Remove troublesome punctuation (, . ?)
+        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + network_sep_scene_prev + searchData.encoded + network_sep_scene)
         searchResults = HTML.ElementFromString(req.text)
         for searchResult in searchResults.xpath('//div[@class="tlcDetails"]'):
             titleNoFormatting = searchResult.xpath('.//a[1]')[0].text_content().strip()
@@ -120,10 +120,10 @@ def search(results, lang, siteNum, search):
                     releaseDate = parse(detailsPageElements.xpath('//*[@class="updatedDate"]')[0].text_content().strip()).strftime('%Y-%m-%d')
                 except:
                     releaseDate = ''
-            if search['date'] and releaseDate:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date and releaseDate:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name=titleNoFormatting + actor + " [" + network + PAsearchSites.getSearchSiteName(siteNum) + "] " + releaseDate, score=score, lang=lang))
 
@@ -132,7 +132,7 @@ def search(results, lang, siteNum, search):
             i = 2
             while i < 3:
                 pagenum = i
-                req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + network_sep_scene_pages_prev + search['encoded'] + network_sep_scene_pages + str(pagenum) + network_sep_scene_pages_next)
+                req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + network_sep_scene_pages_prev + searchData.encoded + network_sep_scene_pages + str(pagenum) + network_sep_scene_pages_next)
                 searchResultsSec = HTML.ElementFromString(req.text)
                 i += 1
                 searchResultSec = searchResultsSec.xpath('//div[@class="tlcDetails"]')
@@ -180,10 +180,10 @@ def search(results, lang, siteNum, search):
                             except:
                                 releaseDate = ''
 
-                        if search['date'] and releaseDate:
-                            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+                        if searchData.date and releaseDate:
+                            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
                         else:
-                            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
                         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name=titleNoFormatting + actor + " [" + network + PAsearchSites.getSearchSiteName(siteNum) + "] " + releaseDate, score=score, lang=lang))
 
@@ -195,8 +195,8 @@ def search(results, lang, siteNum, search):
     if directmatch:
         # Result to check
         resultfirst = []
-        searchString = search['encoded'].replace("%20", '-').lower()
-        # searchResults = HTML.ElementFromURL(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'] + "?query=" + search['encoded'])
+        searchString = searchData.encoded.replace("%20", '-').lower()
+        # searchResults = HTML.ElementFromURL(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded + "?query=" + searchData.encoded)
         req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchString)
         searchResults = HTML.ElementFromString(req.text)
         for searchResult in searchResults.xpath('//div[@id="infoWrapper"]'):
@@ -212,16 +212,16 @@ def search(results, lang, siteNum, search):
             except:
                 releaseDate = ''
 
-            if search['date'] and releaseDate:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date and releaseDate:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name=titleNoFormatting + " [" + network + PAsearchSites.getSearchSiteName(siteNum) + "] " + releaseDate, score=score, lang=lang))
 
     if networkdvd:
         try:
-            req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + network_sep_dvd_prev + search['encoded'] + network_sep_dvd)
+            req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + network_sep_dvd_prev + searchData.encoded + network_sep_dvd)
             dvdResults = HTML.ElementFromString(req.text)
             for dvdResult in dvdResults.xpath('//div[contains(@class,"tlcItem playlistable_dvds")] | //div[@class="tlcDetails"]'):
                 titleNoFormatting = dvdResult.xpath('.//div[@class="tlcTitle"]/a')[0].get('title').strip()
@@ -236,7 +236,7 @@ def search(results, lang, siteNum, search):
                     except:
                         releaseDate = ''
 
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
                 results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name=titleNoFormatting + " (" + releaseDate.strftime('%Y') + ") - Full Movie [" + PAsearchSites.getSearchSiteName(siteNum) + "]", score=score, lang=lang))
         except:

--- a/Contents/Code/networkGammaEntOther.py
+++ b/Contents/Code/networkGammaEntOther.py
@@ -21,23 +21,23 @@ def getAlgolia(url, indexName, params, referer):
     return data['results'][0]['hits']
 
 
-def search(results, lang, siteNum, search):
-    sceneID = search['title'].split(' ', 1)[0]
+def search(results, lang, siteNum, searchData):
+    sceneID = searchData.title.split(' ', 1)[0]
     if unicode(sceneID, 'UTF-8').isdigit():
-        search['title'] = search['title'].replace(sceneID, '', 1).strip()
+        searchData.title = searchData.title.replace(sceneID, '', 1).strip()
     else:
         sceneID = None
 
     apiKEY = getAPIKey(PAsearchSites.getSearchBaseURL(siteNum))
     for sceneType in ['scenes', 'movies']:
         url = PAsearchSites.getSearchSearchURL(siteNum) + '?x-algolia-application-id=TSMKFA364Q&x-algolia-api-key=' + apiKEY
-        if sceneID and not search['title']:
+        if sceneID and not searchData.title:
             if sceneType == 'scenes':
                 params = 'filters=clip_id=' + sceneID
             else:
                 params = 'filters=movie_id=' + sceneID
         else:
-            params = 'query=' + search['title']
+            params = 'query=' + searchData.title
 
         searchResults = getAlgolia(url, 'all_' + sceneType, params, PAsearchSites.getSearchBaseURL(siteNum))
         for searchResult in searchResults:
@@ -54,10 +54,10 @@ def search(results, lang, siteNum, search):
 
             if sceneID:
                 score = 100 - Util.LevenshteinDistance(sceneID, curID)
-            elif search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            elif searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%d|%d|%s|%s' % (curID, siteNum, sceneType, releaseDate), name='[%s] %s %s' % (sceneType.capitalize(), titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/networkHighTechVR.py
+++ b/Contents/Code/networkHighTechVR.py
@@ -2,13 +2,13 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].lower().replace(' ', '-', 1).replace(' ', '_')
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.lower().replace(' ', '-', 1).replace(' ', '_')
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
 
     titleNoFormatting = searchResults.xpath('//h1')[0].text_content().strip()
-    curID = search['encoded']
+    curID = searchData.encoded
 
     date = searchResults.xpath('//span[@class="date-display-single"] | //span[@class="u-inline-block u-mr--nine"] | //div[@class="video-meta-date"] | //div[@class="date"]')[0].text_content().strip()
     releaseDate = parse(date).strftime('%Y-%m-%d')

--- a/Contents/Code/networkIntersec.py
+++ b/Contents/Code/networkIntersec.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[contains(@class, "is-multiline")]/div[contains(@class, "column")]'):
         curID = PAutils.Encode(searchResult.xpath('.//a/@href')[0])
@@ -11,10 +11,10 @@ def search(results, lang, siteNum, search):
         releaseDate = parse(searchResult.xpath('.//span[contains(@class, "tag")]/text()')[0]).strftime('%Y-%m-%d')
         scenePoster = PAutils.Encode(searchResult.xpath('.//img/@src')[0])
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, scenePoster), name='%s [Intersec/%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/networkJavBus.py
+++ b/Contents/Code/networkJavBus.py
@@ -2,15 +2,15 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     searchJAVID = None
-    splitsearch['title'] = search['title'].split()
-    if len(splitsearch['title']) > 1:
-        if unicode(splitsearch['title'][1], 'UTF-8').isdigit():
-            searchJAVID = '%s%%2B%s' % (splitsearch['title'][0], splitsearch['title'][1])
+    splitsearchData.title = searchData.title.split()
+    if len(splitsearchData.title) > 1:
+        if unicode(splitsearchData.title[1], 'UTF-8').isdigit():
+            searchJAVID = '%s%%2B%s' % (splitsearchData.title[0], splitsearchData.title[1])
 
     if searchJAVID:
-        search['encoded'] = searchJAVID
+        searchData.encoded = searchJAVID
 
     searchTypes = [
         'Censored',
@@ -19,9 +19,9 @@ def search(results, lang, siteNum, search):
 
     for searchType in searchTypes:
         if searchType == 'Uncensored':
-            sceneURL = PAsearchSites.getSearchSearchURL(siteNum) + 'uncensored/search/' + search['encoded']
+            sceneURL = PAsearchSites.getSearchSearchURL(siteNum) + 'uncensored/search/' + searchData.encoded
         elif searchType == 'Censored':
-            sceneURL = PAsearchSites.getSearchSearchURL(siteNum) + 'search/' + search['encoded']
+            sceneURL = PAsearchSites.getSearchSearchURL(siteNum) + 'search/' + searchData.encoded
 
         req = PAutils.HTTPRequest(sceneURL)
         searchResults = HTML.ElementFromString(req.text)
@@ -35,7 +35,7 @@ def search(results, lang, siteNum, search):
             if searchJAVID:
                 score = 100 - Util.LevenshteinDistance(searchJAVID.lower(), JAVID.lower())
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='[%s][%s] %s' % (searchType, JAVID, titleNoFormatting), score=score, lang=lang))
 

--- a/Contents/Code/networkKink.py
+++ b/Contents/Code/networkKink.py
@@ -2,11 +2,11 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     shootID = None
-    for splited in search['title'].split():
-        if unicode(splited, 'UTF-8').isdigit():
-            shootID = splited
+    for parts in searchData.title.split():
+        if unicode(parts, 'UTF-8').isdigit():
+            shootID = parts
             break
 
     if shootID:
@@ -20,7 +20,7 @@ def search(results, lang, siteNum, search):
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='[%s] %s [%s] %s' % (shootID, titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=100, lang=lang))
     else:
-        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
         searchResults = HTML.ElementFromString(req.text)
         for searchResult in searchResults.xpath('//div[@class="shoot-card scene"]'):
             titleNoFormatting = searchResult.xpath('.//img/@alt')[0].strip()
@@ -28,10 +28,10 @@ def search(results, lang, siteNum, search):
             releaseDate = parse(searchResult.xpath('.//div[@class="date"]')[0].text_content().strip()).strftime('%Y-%m-%d')
             shootID = searchResult.xpath('.//span[contains(@class, "favorite-button")]/@data-id')[0]
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='[%s] %s [%s] %s' % (shootID, titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/networkMetArt.py
+++ b/Contents/Code/networkMetArt.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + '/search-results?query[contentType]=movies&searchPhrase=' + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + '/search-results?query[contentType]=movies&searchPhrase=' + searchData.encoded)
     searchResults = req.json()
     for searchResult in searchResults['items']:
         subSite = PAsearchSites.getSearchSiteName(siteNum)
@@ -14,10 +14,10 @@ def search(results, lang, siteNum, search):
         curID = PAutils.Encode(sceneURL)
 
         releaseDate = parse(searchResult['item']['publishedAt']).strftime('%Y-%m-%d')
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [MetArt/%s] %s' % (titleNoFormatting, subSite, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/networkModelCentro.py
+++ b/Contents/Code/networkModelCentro.py
@@ -28,7 +28,7 @@ def getJSONfromAPI(url):
     return None
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     apiurl = getAPIURL(PAsearchSites.getSearchBaseURL(siteNum) + '/videos/')
     searchResults = getJSONfromAPI(PAsearchSites.getSearchSearchURL(siteNum) + apiurl + query)
 
@@ -37,18 +37,18 @@ def search(results, lang, siteNum, search):
             sceneID = str(searchResult['id'])
             releaseDate = parse(searchResult.get('sites').get('collection').get(sceneID).get('publishDate')).strftime('%Y-%m-%d')
 
-            if search['date']:
-                delta = abs(parse(search['date']) - parse(releaseDate))
+            if searchData.date:
+                delta = abs(parse(searchData.date) - parse(releaseDate))
                 if delta.days < 2:
                     artobj = PAutils.Encode(json.dumps(searchResult.get('_resources').get('base')))
                     titleNoFormatting = str(searchResult['title'])
-                    score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+                    score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
                     results.Append(MetadataSearchResult(id='%s|%d|%s|%s' % (sceneID, siteNum, titleNoFormatting, artobj),
                                                         name='%s %s [%s]' % (titleNoFormatting, releaseDate, PAsearchSites.getSearchSiteName(siteNum)),
                                                         score=score, lang=lang))
             else:
                 titleNoFormatting = str(searchResult['title'])
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
                 if score >= 90:
                     artobj = PAutils.Encode(json.dumps(searchResult.get('_resources').get('base')))

--- a/Contents/Code/networkNubiles.py
+++ b/Contents/Code/networkNubiles.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    if search['date']:
-        url = PAsearchSites.getSearchSearchURL(siteNum) + 'date/' + search['date'] + '/' + search['date']
+def search(results, lang, siteNum, searchData):
+    if searchData.date:
+        url = PAsearchSites.getSearchSearchURL(siteNum) + 'date/' + searchData.date + '/' + searchData.date
         req = PAutils.HTTPRequest(url)
         searchResults = HTML.ElementFromString(req.text)
         for searchResult in searchResults.xpath('//div[contains(@class, "content-grid-item")]'):
@@ -12,14 +12,14 @@ def search(results, lang, siteNum, search):
             curID = searchResult.xpath('//span[@class="title"]/a/@href')[0].split('/')[3]
             releaseDate = parse(searchResult.xpath('.//span[@class="date"]')[0].text_content().strip()).strftime('%Y-%m-%d')
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 
-    sceneID = search['title'].split()[0]
+    sceneID = searchData.title.split()[0]
     if unicode(sceneID, 'utf-8').isdigit():
         sceneURL = PAsearchSites.getSearchBaseURL(siteNum) + '/video/watch/' + sceneID
         req = PAutils.HTTPRequest(sceneURL)

--- a/Contents/Code/networkPerfectGonzo.py
+++ b/Contents/Code/networkPerfectGonzo.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="itemm"]'):
         titleNoFormatting = searchResult.xpath('.//a/@title')[0]
@@ -34,10 +34,10 @@ def search(results, lang, siteNum, search):
         else:
             subSite = PAsearchSites.getSearchSiteName(siteNum)
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [Perfect Gonzo/%s] %s' % (titleNoFormatting, subSite, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/networkPervCity.py
+++ b/Contents/Code/networkPervCity.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     searchResults = []
 
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         sceneURL = sceneURL.replace('www.', '')
         if ('trailers' in sceneURL) and 'as3' not in sceneURL and sceneURL not in searchResults:
@@ -23,13 +23,13 @@ def search(results, lang, siteNum, search):
         if date:
             releaseDate = parse(date).strftime('%Y-%m-%d')
         else:
-            releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+            releaseDate = searchData.dateFormat() if searchData.date else ''
         displayDate = releaseDate if date else ''
 
-        if search['date'] and displayDate:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date and displayDate:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [PervCity/%s]' % (titleNoFormatting, subSite), score=score, lang=lang))
 

--- a/Contents/Code/networkPornFidelity.py
+++ b/Contents/Code/networkPornFidelity.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'], cookies={'nats': 'MC4wLjMuNTguMC4wLjAuMC4w'})
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded, cookies={'nats': 'MC4wLjMuNTguMC4wLjAuMC4w'})
     searchResults = HTML.ElementFromString(req.json()['html'])
     for searchResult in searchResults.xpath('//div[@class="card episode"]'):
         titleNoFormatting = searchResult.xpath('.//a[@class="text-km"] | .//a[@class="text-pf"] | .//a[@class="text-tf"]')[0].text_content().strip()
@@ -16,10 +16,10 @@ def search(results, lang, siteNum, search):
             releaseDate = releaseDate + ', ' + str(datetime.now().year)
         releaseDate = parse(releaseDate).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/networkPornPros.py
+++ b/Contents/Code/networkPornPros.py
@@ -3,15 +3,15 @@ import PAextras
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     searchResults = []
 
-    directURL = PAsearchSites.getSearchSearchURL(siteNum) + search['title'].lower().replace(' ', '-')
+    directURL = PAsearchSites.getSearchSearchURL(siteNum) + searchData.title.lower().replace(' ', '-')
     if unicode(directURL[-1], 'UTF-8').isdigit() and directURL[-2] == '-':
         directURL = '%s-%s' % (directURL[:-1], directURL[-1])
     searchResults.append(directURL)
 
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         if ('/video/' in sceneURL and sceneURL not in searchResults):
             searchResults.append(sceneURL)
@@ -23,9 +23,9 @@ def search(results, lang, siteNum, search):
             titleNoFormatting = detailsPageElements.xpath('//h1')[0].text_content().strip()
             curID = PAutils.Encode(sceneURL)
 
-            releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+            releaseDate = searchData.dateFormat() if searchData.date else ''
 
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/networkPornWorld.py
+++ b/Contents/Code/networkPornWorld.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    sceneID = search['title'].split(' ', 1)[0]
+def search(results, lang, siteNum, searchData):
+    sceneID = searchData.title.split(' ', 1)[0]
     if unicode(sceneID, 'UTF-8').isdigit():
-        search['title'] = search['title'].replace(sceneID, '', 1).strip()
+        searchData.title = searchData.title.replace(sceneID, '', 1).strip()
     else:
         sceneID = None
 
@@ -19,8 +19,8 @@ def search(results, lang, siteNum, search):
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name=titleNoFormatting, score=100, lang=lang))
     else:
-        search['encoded'] = search['title'].replace(' ', '+')
-        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+        searchData.encoded = searchData.title.replace(' ', '+')
+        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
         searchResults = HTML.ElementFromString(req.text)
         for searchResult in searchResults.xpath('//div[@class="thumbnail  thumbnail-premium thumbnail-old"]'):
             titleNoFormatting = searchResult.xpath('.//div[@class="thumbnail-title gradient"]/a/@title')[0]
@@ -31,10 +31,10 @@ def search(results, lang, siteNum, search):
 
             curID = PAutils.Encode(url)
 
-            if search['date'] and releaseDate:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date and releaseDate:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/networkPuffy.py
+++ b/Contents/Code/networkPuffy.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@style="position:relative; background:black;"]'):
         titleNoFormatting = searchResult.xpath('.//a/@title')[0]
@@ -21,9 +21,9 @@ def search(results, lang, siteNum, search):
             SubSite = 'Euro Babe Facials'
 
         curID = PAutils.Encode(searchResult.xpath('.//a/@href')[0])
-        releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+        releaseDate = searchData.dateFormat() if searchData.date else ''
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [Puffy Network/%s]' % (titleNoFormatting, SubSite), score=score, lang=lang))
 

--- a/Contents/Code/networkPureCFNM.py
+++ b/Contents/Code/networkPureCFNM.py
@@ -2,17 +2,17 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     try:
-        modelID = '-'.join(search['title'].split(' ', 2)[:2])
+        modelID = '-'.join(searchData.title.split(' ', 2)[:2])
         try:
-            sceneTitle = search['title'].split(' ', 2)[2]
+            sceneTitle = searchData.title.split(' ', 2)[2]
         except:
             sceneTitle = ''
     except:
-        modelID = search['title'].split(' ', 1)[0]
+        modelID = searchData.title.split(' ', 1)[0]
         try:
-            sceneTitle = search['title'].split(' ', 1)[1]
+            sceneTitle = searchData.title.split(' ', 1)[1]
         except:
             sceneTitle = ''
 
@@ -41,8 +41,8 @@ def search(results, lang, siteNum, search):
         descriptionID = PAutils.Encode(description)
         posterID = PAutils.Encode(poster)
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         elif sceneTitle:
             score = 100 - Util.LevenshteinDistance(sceneTitle.lower(), titleNoFormatting.lower())
         else:

--- a/Contents/Code/networkR18.py
+++ b/Contents/Code/networkR18.py
@@ -2,17 +2,17 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     searchJAVID = None
-    splitsearch['title'] = search['title'].split()
-    if len(splitsearch['title']) > 1:
-        if unicode(splitsearch['title'][1], 'UTF-8').isdigit():
-            searchJAVID = '%s%%2B%s' % (splitsearch['title'][0], splitsearch['title'][1])
+    splitsearchData.title = searchData.title.split()
+    if len(splitsearchData.title) > 1:
+        if unicode(splitsearchData.title[1], 'UTF-8').isdigit():
+            searchJAVID = '%s%%2B%s' % (splitsearchData.title[0], splitsearchData.title[1])
 
     if searchJAVID:
-        search['encoded'] = searchJAVID
+        searchData.encoded = searchJAVID
 
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//li[contains(@class, "item-list")]'):
         titleNoFormatting = searchResult.xpath('.//dt')[0].text_content().strip()
@@ -24,7 +24,7 @@ def search(results, lang, siteNum, search):
         if searchJAVID:
             score = 100 - Util.LevenshteinDistance(searchJAVID.lower(), JAVID.lower())
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='[%s] %s' % (JAVID, titleNoFormatting), score=score, lang=lang))
 

--- a/Contents/Code/networkScoreGroup.py
+++ b/Contents/Code/networkScoreGroup.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    sceneID = re.sub(r'\D', '', search['title'])
-    actorName = re.sub(r'\s\d.*', '', search['title']).replace(' ', '-')
+def search(results, lang, siteNum, searchData):
+    sceneID = re.sub(r'\D', '', searchData.title)
+    actorName = re.sub(r'\s\d.*', '', searchData.title).replace(' ', '-')
     sceneURL = PAsearchSites.getSearchSearchURL(siteNum) + actorName + '/' + sceneID
 
     req = PAutils.HTTPRequest(sceneURL)

--- a/Contents/Code/networkSinX.py
+++ b/Contents/Code/networkSinX.py
@@ -2,14 +2,14 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="view_grid--container"]'):
         titleNoFormatting = searchResult.xpath('.//div[@class="video_item--content with-badge"]/a/@title')[0]
         curID = PAutils.Encode(searchResult.xpath('.//div[@class="video_item--content with-badge"]/a/@href')[0])
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [Pissing in Action]' % titleNoFormatting, score=score, lang=lang))
 

--- a/Contents/Code/networkSteppedUp.py
+++ b/Contents/Code/networkSteppedUp.py
@@ -2,12 +2,12 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].replace(' ', '-').replace('--', '-').replace('\'', '').lower()
-    if '/' not in search['encoded']:
-        search['encoded'] = search['encoded'].replace('-', '/', 1)
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.replace(' ', '-').replace('--', '-').replace('\'', '').lower()
+    if '/' not in searchData.encoded:
+        searchData.encoded = searchData.encoded.replace('-', '/', 1)
 
-    sceneURL = PAsearchSites.getSearchSearchURL(siteNum) + search['encoded']
+    sceneURL = PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded
     req = PAutils.HTTPRequest(sceneURL)
     detailsPageElements = HTML.ElementFromString(req.text)
 
@@ -18,13 +18,13 @@ def search(results, lang, siteNum, search):
     if date:
         releaseDate = parse(date[0].text_content().strip()).strftime('%Y-%m-%d')
     else:
-        releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+        releaseDate = searchData.dateFormat() if searchData.date else ''
     displayDate = releaseDate if date else ''
 
-    if search['date'] and displayDate:
-        score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+    if searchData.date and displayDate:
+        score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
     else:
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
     results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/networkStrike3.py
+++ b/Contents/Code/networkStrike3.py
@@ -10,8 +10,8 @@ def getDatafromAPI(url):
     return req
 
 
-def search(results, lang, siteNum, search):
-    url = PAsearchSites.getSearchSearchURL(siteNum) + '/search?q=' + search['encoded']
+def search(results, lang, siteNum, searchData):
+    url = PAsearchSites.getSearchSearchURL(siteNum) + '/search?q=' + searchData.encoded
 
     searchResults = getDatafromAPI(url)
     if searchResults:
@@ -20,10 +20,10 @@ def search(results, lang, siteNum, search):
             releaseDate = parse(searchResult['releaseDate']).strftime('%Y-%m-%d')
             curID = PAutils.Encode(searchResult['targetUrl'])
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/networkTeamSkeet.py
+++ b/Contents/Code/networkTeamSkeet.py
@@ -31,11 +31,11 @@ def getDataFromAPI(dbURL, sceneType, sceneName, siteNum):
     return None
 
 
-def search(results, lang, siteNum, search):
-    directURL = search['title'].replace(' ', '-').lower()
+def search(results, lang, siteNum, searchData):
+    directURL = searchData.title.replace(' ', '-').lower()
 
     searchResults = [directURL]
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         sceneURL = sceneURL.split('?', 1)[0]
         sceneName = None
@@ -62,14 +62,14 @@ def search(results, lang, siteNum, search):
             if 'publishedDate' in detailsPageElements:
                 releaseDate = parse(detailsPageElements['publishedDate']).strftime('%Y-%m-%d')
             else:
-                releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+                releaseDate = searchData.dateFormat() if searchData.date else ''
 
             displayDate = releaseDate if 'publishedDate' in detailsPageElements else ''
 
-            if search['date'] and displayDate:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date and displayDate:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d|%s|%s' % (curID, siteNum, releaseDate, sceneType), name='%s [%s] %s' % (titleNoFormatting, siteName, displayDate), score=score, lang=lang))
 

--- a/Contents/Code/networkTeenCoreClub.py
+++ b/Contents/Code/networkTeenCoreClub.py
@@ -2,12 +2,12 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     sceneID = None
-    splited = search['title'].split()
-    if unicode(splited[0], 'UTF-8').isdigit():
-        sceneID = splited[0]
-        search['title'] = search['title'].replace(sceneID, '', 1).strip()
+    parts = searchData.title.split()
+    if unicode(parts[0], 'UTF-8').isdigit():
+        sceneID = parts[0]
+        searchData.title = searchData.title.replace(sceneID, '', 1).strip()
 
     if sceneID:
         sceneURL = PAsearchSites.getSearchSearchURL(siteNum) + sceneID

--- a/Contents/Code/networkTeenMegaWorld.py
+++ b/Contents/Code/networkTeenMegaWorld.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     for searchPageNum in range(1, 3):
-        url = PAsearchSites.getSearchSearchURL(siteNum) + '%%22%s%%22&page=%d' % (search['title'].replace(' ', '+'), searchPageNum)
+        url = PAsearchSites.getSearchSearchURL(siteNum) + '%%22%s%%22&page=%d' % (searchData.title.replace(' ', '+'), searchPageNum)
         req = PAutils.HTTPRequest(url)
         searchResults = HTML.ElementFromString(req.text)
         for searchResult in searchResults.xpath('//article'):
@@ -14,10 +14,10 @@ def search(results, lang, siteNum, search):
                 releaseDate = parse(searchResult.xpath('.//time')[0].text_content()).strftime('%Y-%m-%d')
                 subSite = searchResult.xpath('.//div[@class="site"]/a')[0].text_content().replace('.com', '').strip()
 
-                if search['date']:
-                    score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+                if searchData.date:
+                    score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
                 else:
-                    score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                    score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
                 results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [TMW/%s] %s' % (titleNoFormatting, subSite, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/networkTwoWebMedia.py
+++ b/Contents/Code/networkTwoWebMedia.py
@@ -2,15 +2,15 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="loop_content search"]'):
         titleNoFormatting = searchResult.xpath('.//h2[@class="post_title"]/a')[0].text_content().strip()
         sceneURL = searchResult.xpath('.//h2[@class="post_title"]/a/@href')[0]
         curID = PAutils.Encode(sceneURL)
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         if '/videoentry/' in sceneURL:
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [TwoWebMedia/%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))

--- a/Contents/Code/networkWankz.py
+++ b/Contents/Code/networkWankz.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="scene"]'):
         titleNoFormatting = searchResult.xpath('.//div[@class="title-wrapper"]//a[@class="title"]')[0].text_content()
@@ -11,7 +11,7 @@ def search(results, lang, siteNum, search):
         subSite = searchResult.xpath('.//div[@class="series-container"]//a[@class="sitename"]')[0].text_content()
 
         siteScore = 80 - (Util.LevenshteinDistance(subSite.lower(), PAsearchSites.getSearchSiteName(siteNum).lower()) * 8 / 10)
-        titleScore = 20 - (Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower()) * 2 / 10)
+        titleScore = 20 - (Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower()) * 2 / 10)
         score = siteScore + titleScore
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s]' % (titleNoFormatting, subSite), score=score, lang=lang))

--- a/Contents/Code/site18OnlyGirls.py
+++ b/Contents/Code/site18OnlyGirls.py
@@ -3,10 +3,10 @@ import PAextras
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     searchResults = []
 
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         if ('/search/' not in sceneURL and '/page/' not in sceneURL and '/tag/' not in sceneURL and sceneURL not in searchResults):
             searchResults.append(sceneURL)
@@ -23,13 +23,13 @@ def search(results, lang, siteNum, search):
                 if date:
                     releaseDate = parse(date).strftime('%Y-%m-%d')
                 else:
-                    releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+                    releaseDate = searchData.dateFormat() if searchData.date else ''
                 displayDate = releaseDate if date else ''
 
-                if search['date'] and displayDate:
-                    score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+                if searchData.date and displayDate:
+                    score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
                 else:
-                    score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                    score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
                 results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteATKGirlfriends.py
+++ b/Contents/Code/siteATKGirlfriends.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    modelID = search['title'].split(' ', 1)[0].lower()
+def search(results, lang, siteNum, searchData):
+    modelID = searchData.title.split(' ', 1)[0].lower()
     try:
-        sceneTitle = search['title'].split(' ', 1)[1]
+        sceneTitle = searchData.title.split(' ', 1)[1]
     except:
         sceneTitle = ''
 
@@ -31,7 +31,7 @@ def search(results, lang, siteNum, search):
         posterID = PAutils.Encode(poster)
 
         actor = searchResult.xpath('//h1[@class="page-title col-lg-12"]')[0].text_content().strip()
-        releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+        releaseDate = searchData.dateFormat() if searchData.date else ''
 
         curID = PAutils.Encode(searchResult.xpath('.//a[@class="thumbnail left"]/@href')[0])
 

--- a/Contents/Code/siteAllAnalAllTheTime.py
+++ b/Contents/Code/siteAllAnalAllTheTime.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    sceneID = search['title'].split(' ', 1)[0]
+def search(results, lang, siteNum, searchData):
+    sceneID = searchData.title.split(' ', 1)[0]
     if unicode(sceneID, 'UTF-8').isdigit():
-        search['title'] = search['title'].replace(sceneID, '', 1).strip()
+        searchData.title = searchData.title.replace(sceneID, '', 1).strip()
     else:
         sceneID = None
 
@@ -14,7 +14,7 @@ def search(results, lang, siteNum, search):
         directURL = PAsearchSites.getSearchSearchURL(siteNum) + sceneID
         searchResults.append(directURL)
 
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         if ('/videos/' in sceneURL and sceneURL not in searchResults):
             searchResults.append(sceneURL)
@@ -31,10 +31,10 @@ def search(results, lang, siteNum, search):
             if date:
                 releaseDate = parse(date).strftime('%Y-%m-%d')
 
-            if search['date'] and releaseDate:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date and releaseDate:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='[%s] %s %s' % (PAsearchSites.getSearchSiteName(siteNum), titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteAllureMedia.py
+++ b/Contents/Code/siteAllureMedia.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
 
     # Amateur Allure
@@ -13,10 +13,10 @@ def search(results, lang, siteNum, search):
             releaseDate = parse(searchResult.xpath('.//div[@class="update_date"]')[0].text_content().replace('Added:', '').strip()).strftime('%Y-%m-%d')
             curID = PAutils.Encode(searchResult.xpath('.//a[1]/@href')[0])
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             if len(titleNoFormatting) > 29:
                 titleNoFormatting = titleNoFormatting[:32] + '...'
@@ -30,10 +30,10 @@ def search(results, lang, siteNum, search):
             releaseDate = parse(searchResult.xpath('.//div[@class="cell update_date"]')[0].text_content().strip()).strftime('%Y-%m-%d')
             curID = PAutils.Encode(searchResult.xpath('./a[2]/@href')[0])
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             if len(titleNoFormatting) > 29:
                 titleNoFormatting = titleNoFormatting[:32] + '...'

--- a/Contents/Code/siteAlsAngels.py
+++ b/Contents/Code/siteAlsAngels.py
@@ -2,17 +2,17 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum))
     detailsPageElements = HTML.ElementFromString(req.text)
     parent = ''
 
-    if search['date']:
+    if searchData.date:
         Log('*** date search')
-        parent = detailsPageElements.xpath('//tr[.//span[@class="videodate" and text()=\'Date: %s\']]' % parse(search['date']).strftime('%B %d, %Y'))
-    elif search['title']:
+        parent = detailsPageElements.xpath('//tr[.//span[@class="videodate" and text()=\'Date: %s\']]' % searchData.dateFormat('%B %d, %Y'))
+    elif searchData.title:
         Log('*** title search')
-        m = re.search(r'([a-z0-9\&\; ]+) (masturbation|photoshoot|interview|girl-girl action|pov lapdance)', search['title'], re.IGNORECASE)
+        m = re.search(r'([a-z0-9\&\; ]+) (masturbation|photoshoot|interview|girl-girl action|pov lapdance)', searchData.title, re.IGNORECASE)
         if m:
             parent = detailsPageElements.xpath('//tr[.//h2[@class="videomodel" and contains(text(), "%s")] and .//span[@class="videotype" and contains(text(), "%s")]]' % (m.group(1), m.group(2)))
 

--- a/Contents/Code/siteAmourAngels.py
+++ b/Contents/Code/siteAmourAngels.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    sceneID = search['title'].split(' ', 1)[0]
+def search(results, lang, siteNum, searchData):
+    sceneID = searchData.title.split(' ', 1)[0]
     try:
-        sceneTitle = search['title'].split(' ', 1)[1]
+        sceneTitle = searchData.title.split(' ', 1)[1]
     except:
         sceneTitle = ''
 

--- a/Contents/Code/siteAngelaWhite.py
+++ b/Contents/Code/siteAngelaWhite.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="videodetails"]'):
         titleNoFormatting = searchResult.xpath('./div[contains(@class, "videocontent")]/@data-title')[0]
@@ -18,7 +18,7 @@ def search(results, lang, siteNum, search):
             pass
         releaseDate = parse(date).strftime('%Y-%m-%d') if date else ''
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
         results.Append(MetadataSearchResult(id='%s|%d|%s|%s' % (curID, siteNum, titleNoFormatting, releaseDate), name='%s %s [%s]' % (titleNoFormatting, releaseDate, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 
     return results

--- a/Contents/Code/siteArchAngel.py
+++ b/Contents/Code/siteArchAngel.py
@@ -2,14 +2,14 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[contains(@class, "item-video")]'):
         titleNoFormatting = searchResult.xpath('./div[@class="item-thumb"]/a/@title')[0]
         curID = PAutils.Encode(searchResult.xpath('./div[@class="item-thumb"]/a/@href')[0])
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [ArchAngel]' % titleNoFormatting, score=score, lang=lang))
 

--- a/Contents/Code/siteAussieAss.py
+++ b/Contents/Code/siteAussieAss.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
 
-    sceneID = re.sub(r'\D.*', '', search['title'])
+    sceneID = re.sub(r'\D.*', '', searchData.title)
 
     if sceneID:
         sceneURL = PAsearchSites.getSearchBaseURL(siteNum) + "/webmasters/" + sceneID
@@ -19,26 +19,26 @@ def search(results, lang, siteNum, search):
     else:
         # Handle 3 Types of Links: First, Last; First Only; First-Last
         try:
-            search['encoded'] = re.search(r'^\S*.\S*', search['title']).group(0).replace(' ', '').lower()
+            searchData.encoded = re.search(r'^\S*.\S*', searchData.title).group(0).replace(' ', '').lower()
 
-            req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'] + ".html")
+            req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded + ".html")
             searchResults = HTML.ElementFromString(req.text)
 
             if searchResults.xpath('//html')[0].text_content() == 'Page not found':
                 raise Exception
         except:
             try:
-                search['encoded'] = re.search(r'^\S*.\S*', search['title']).group(0).replace(' ', '-').lower()
+                searchData.encoded = re.search(r'^\S*.\S*', searchData.title).group(0).replace(' ', '-').lower()
 
-                req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'] + ".html")
+                req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded + ".html")
                 searchResults = HTML.ElementFromString(req.text)
 
                 if searchResults.xpath('//html')[0].text_content() == 'Page not found':
                     raise Exception
             except:
-                search['encoded'] = re.search(r'^\S*', search['title']).group(0).lower()
+                searchData.encoded = re.search(r'^\S*', searchData.title).group(0).lower()
 
-                req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'] + ".html")
+                req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded + ".html")
                 searchResults = HTML.ElementFromString(req.text)
         try:
             pageResults = (int)(searchResults.xpath('//span[@class="number_item "]')[0].text_content().strip())
@@ -65,16 +65,16 @@ def search(results, lang, siteNum, search):
                 if date:
                     releaseDate = parse(date).strftime('%Y-%m-%d')
                 else:
-                    releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+                    releaseDate = searchData.dateFormat() if searchData.date else ''
                 releaseDate = parse(date).strftime('%Y-%m-%d')
                 displayDate = releaseDate if date else ''
 
                 if sceneID == resultID:
                     score = 100
-                elif search['date'] and displayDate:
-                    score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+                elif searchData.date and displayDate:
+                    score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
                 else:
-                    score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                    score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
                 results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteBAMVisions.py
+++ b/Contents/Code/siteBAMVisions.py
@@ -2,15 +2,15 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="category_listing_wrapper_updates"]'):
         titleNoFormatting = searchResult.xpath('.//h3/a')[0].text_content().strip()
         curID = PAutils.Encode(searchResult.xpath('.//h3/a/@href')[0])
         videoBG = PAutils.Encode(searchResult.xpath('.//img/@src0_3x')[0])
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, videoBG), name='%s [BAMVisions]' % titleNoFormatting, score=score, lang=lang))
 

--- a/Contents/Code/siteBlackPayBack.py
+++ b/Contents/Code/siteBlackPayBack.py
@@ -2,12 +2,12 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].lower().replace(' ', '-')
-    directURL = PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'] + '.html'
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.lower().replace(' ', '-')
+    directURL = PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded + '.html'
 
     searchResults = [directURL]
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         if '/trailers/' in sceneURL and sceneURL not in searchResults:
             searchResults.append(sceneURL)
@@ -19,7 +19,7 @@ def search(results, lang, siteNum, search):
         titleNoFormatting = detailsPageElements.xpath('//h1')[0].text_content().strip()
         curID = PAutils.Encode(sceneURL)
 
-        score = 100 - Util.LevenshteinDistance(search['title'], titleNoFormatting)
+        score = 100 - Util.LevenshteinDistance(searchData.title, titleNoFormatting)
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 

--- a/Contents/Code/siteBoxTruckSex.py
+++ b/Contents/Code/siteBoxTruckSex.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].replace(' ', '+').replace('--', '+').lower()
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.replace(' ', '+').replace('--', '+').lower()
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//ul[@class="slides"]/li'):
         titleNoFormatting = searchResult.xpath('.//h5')[0].text_content().strip()
@@ -15,14 +15,14 @@ def search(results, lang, siteNum, search):
         if date:
             releaseDate = parse(date).strftime('%Y-%m-%d')
         else:
-            releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+            releaseDate = searchData.dateFormat() if searchData.date else ''
         releaseDate = parse(date).strftime('%Y-%m-%d')
         displayDate = releaseDate if date else ''
 
-        if search['date'] and displayDate:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date and displayDate:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteClips4Sale.py
+++ b/Contents/Code/siteClips4Sale.py
@@ -2,12 +2,12 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    userID = search['title'].split(' ', 1)[0]
-    sceneTitle = search['title'].split(' ', 1)[1]
-    search['encoded'] = urllib.quote(sceneTitle)
+def search(results, lang, siteNum, searchData):
+    userID = searchData.title.split(' ', 1)[0]
+    sceneTitle = searchData.title.split(' ', 1)[1]
+    searchData.encoded = urllib.quote(sceneTitle)
 
-    url = PAsearchSites.getSearchSearchURL(siteNum) + userID + '/*/Cat0-AllCategories/Page1/SortBy-bestmatch/Limit50/search/' + search['encoded']
+    url = PAsearchSites.getSearchSearchURL(siteNum) + userID + '/*/Cat0-AllCategories/Page1/SortBy-bestmatch/Limit50/search/' + searchData.encoded
     req = PAutils.HTTPRequest(url)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="clipWrapper"]'):

--- a/Contents/Code/siteClubFilly.py
+++ b/Contents/Code/siteClubFilly.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    sceneID = search['title'].split(' ', 1)[0]
+def search(results, lang, siteNum, searchData):
+    sceneID = searchData.title.split(' ', 1)[0]
 
     req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + sceneID)
     searchResults = HTML.ElementFromString(req.text)

--- a/Contents/Code/siteClubSeventeen.py
+++ b/Contents/Code/siteClubSeventeen.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].replace(' ', '_')
-    sceneURL = PAsearchSites.getSearchSearchURL(siteNum) + search['encoded']
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.replace(' ', '_')
+    sceneURL = PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded
     req = PAutils.HTTPRequest(sceneURL)
     detailsPageElements = HTML.ElementFromString(req.text)
 
@@ -13,8 +13,8 @@ def search(results, lang, siteNum, search):
     date = detailsPageElements.xpath('//p[@class="mt-10 letter-space-1"]')[0].text_content().split('DATE ADDED:')[1].split('|', 1)[0].strip()
     releaseDate = parse(date).strftime('%Y-%m-%d')
 
-    if search['date']:
-        score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+    if searchData.date:
+        score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
     else:
         score = 90
 

--- a/Contents/Code/siteCulioneros.py
+++ b/Contents/Code/siteCulioneros.py
@@ -2,12 +2,12 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     sceneID = None
-    splited = search['title'].split()
-    if unicode(splited[0], 'UTF-8').isdigit():
-        sceneID = splited[0]
-        search['title'] = search['title'].replace(sceneID, '', 1).strip()
+    parts = searchData.title.split()
+    if unicode(parts[0], 'UTF-8').isdigit():
+        sceneID = parts[0]
+        searchData.title = searchData.title.replace(sceneID, '', 1).strip()
 
     if sceneID:
         sceneURL = PAsearchSites.getSearchSearchURL(siteNum) + sceneID + '.htm'

--- a/Contents/Code/siteCumLouder.py
+++ b/Contents/Code/siteCumLouder.py
@@ -3,8 +3,8 @@ import PAutils
 from dateutil.relativedelta import relativedelta
 
 
-def search(results, lang, siteNum, search):
-    url = PAsearchSites.getSearchSearchURL(siteNum) + "%22" + search['encoded'] + "%22"
+def search(results, lang, siteNum, searchData):
+    url = PAsearchSites.getSearchSearchURL(siteNum) + "%22" + searchData.encoded + "%22"
     req = PAutils.HTTPRequest(url)
     searchResults = HTML.ElementFromString(req.text)
 
@@ -12,7 +12,7 @@ def search(results, lang, siteNum, search):
         titleNoFormatting = searchResult.xpath('.//h2')[0].text_content().strip()
         curID = PAutils.Encode(PAsearchSites.getSearchBaseURL(siteNum) + searchResult.get('href'))
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [CumLouder]' % titleNoFormatting, score=score, lang=lang))
 

--- a/Contents/Code/siteCumbizz.py
+++ b/Contents/Code/siteCumbizz.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].replace(' ', '-')
-    sceneURL = PAsearchSites.getSearchSearchURL(siteNum) + search['encoded']
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.replace(' ', '-')
+    sceneURL = PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded
     req = PAutils.HTTPRequest(sceneURL)
     detailsPageElements = HTML.ElementFromString(req.text)
 

--- a/Contents/Code/siteData18Content.py
+++ b/Contents/Code/siteData18Content.py
@@ -3,24 +3,24 @@ import PAextras
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     searchResults = []
     siteResults = []
     temp = []
     count = 0
 
     sceneID = None
-    splited = search['title'].split()
-    if unicode(splited[0], 'UTF-8').isdigit():
-        sceneID = splited[0]
+    parts = searchData.title.split()
+    if unicode(parts[0], 'UTF-8').isdigit():
+        sceneID = parts[0]
 
         if int(sceneID) > 100:
-            search['title'] = search['title'].replace(sceneID, '', 1).strip()
+            searchData.title = searchData.title.replace(sceneID, '', 1).strip()
             sceneURL = '%s/content/%s' % (PAsearchSites.getSearchBaseURL(siteNum), sceneID)
             searchResults.append(sceneURL)
 
-    search['encoded'] = search['title'].replace(' ', '+')
-    searchURL = '%s%s' % (PAsearchSites.getSearchSearchURL(siteNum), search['encoded'])
+    searchData.encoded = searchData.title.replace(' ', '+')
+    searchURL = '%s%s' % (PAsearchSites.getSearchSearchURL(siteNum), searchData.encoded)
     req = PAutils.HTTPRequest(searchURL, headers={'Referer': 'http://www.data18.com'})
     searchPageElements = HTML.ElementFromString(req.text)
 
@@ -62,15 +62,15 @@ def search(results, lang, siteNum, search):
                 date = date.replace('Sept', 'Sep')
                 releaseDate = parse(date).strftime('%Y-%m-%d')
             else:
-                releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+                releaseDate = searchData.dateFormat() if searchData.date else ''
             displayDate = releaseDate if date else ''
 
             if sceneID == urlID:
                 score = 100
-            elif search['date'] and displayDate:
-                score = 80 - Util.LevenshteinDistance(search['date'], releaseDate)
+            elif searchData.date and displayDate:
+                score = 80 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 80 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 80 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             if score == 80:
                 count += 1
@@ -78,7 +78,7 @@ def search(results, lang, siteNum, search):
             else:
                 results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, siteDisplay, displayDate), score=score, lang=lang))
 
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         if ('/content/' in sceneURL and '.html' not in sceneURL and sceneURL not in searchResults and sceneURL not in siteResults):
             searchResults.append(sceneURL)
@@ -117,15 +117,15 @@ def search(results, lang, siteNum, search):
         if date and not date == 'unknown':
             releaseDate = parse(date).strftime('%Y-%m-%d')
         else:
-            releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+            releaseDate = searchData.dateFormat() if searchData.date else ''
         displayDate = releaseDate if date else ''
 
         if sceneID == urlID:
             score = 100
-        elif search['date'] and displayDate:
-            score = 80 - Util.LevenshteinDistance(search['date'], releaseDate)
+        elif searchData.date and displayDate:
+            score = 80 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 80 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 80 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         if score == 80:
             count += 1

--- a/Contents/Code/siteData18Movies.py
+++ b/Contents/Code/siteData18Movies.py
@@ -3,24 +3,24 @@ import PAextras
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     searchResults = []
     siteResults = []
     temp = []
     count = 0
 
     sceneID = None
-    splited = search['title'].split()
-    if unicode(splited[0], 'UTF-8').isdigit():
-        sceneID = splited[0]
+    parts = searchData.title.split()
+    if unicode(parts[0], 'UTF-8').isdigit():
+        sceneID = parts[0]
 
         if int(sceneID) > 100:
-            search['title'] = search['title'].replace(sceneID, '', 1).strip()
+            searchData.title = searchData.title.replace(sceneID, '', 1).strip()
             movieURL = '%s/movies/%s' % (PAsearchSites.getSearchBaseURL(siteNum), sceneID)
             searchResults.append(movieURL)
 
-    search['encoded'] = search['title'].replace(' ', '+')
-    searchURL = '%s%s' % (PAsearchSites.getSearchSearchURL(siteNum), search['encoded'])
+    searchData.encoded = searchData.title.replace(' ', '+')
+    searchURL = '%s%s' % (PAsearchSites.getSearchSearchURL(siteNum), searchData.encoded)
     req = PAutils.HTTPRequest(searchURL, headers={'Referer': 'http://www.data18.com'})
     searchPageElements = HTML.ElementFromString(req.text)
 
@@ -41,15 +41,15 @@ def search(results, lang, siteNum, search):
                 except:
                     releaseDate = ''
             else:
-                releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+                releaseDate = searchData.dateFormat() if searchData.date else ''
             displayDate = releaseDate if date else ''
 
             if sceneID == urlID:
                 score = 100
-            elif search['date'] and displayDate:
-                score = 80 - Util.LevenshteinDistance(search['date'], releaseDate)
+            elif searchData.date and displayDate:
+                score = 80 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 80 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 80 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             if score == 80:
                 count += 1
@@ -57,7 +57,7 @@ def search(results, lang, siteNum, search):
             else:
                 results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s %s' % (titleNoFormatting, displayDate), score=score, lang=lang))
 
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for movieURL in googleResults:
         if ('/movies/' in movieURL and '.html' not in movieURL and movieURL not in searchResults and movieURL not in siteResults):
             searchResults.append(movieURL)
@@ -89,15 +89,15 @@ def search(results, lang, siteNum, search):
         if date and not date == 'unknown':
             releaseDate = parse(date).strftime('%Y-%m-%d')
         else:
-            releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+            releaseDate = searchData.dateFormat() if searchData.date else ''
         displayDate = releaseDate if date else ''
 
         if sceneID == urlID:
             score = 100
-        elif search['date'] and displayDate:
-            score = 80 - Util.LevenshteinDistance(search['date'], releaseDate)
+        elif searchData.date and displayDate:
+            score = 80 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 80 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 80 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         if score == 80:
             count += 1

--- a/Contents/Code/siteDefeated.py
+++ b/Contents/Code/siteDefeated.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//section[@role="main"]/article'):
         titleNoFormatting = searchResult.xpath('.//h2[@itemprop="name"]')[0].text_content().strip()
@@ -16,13 +16,13 @@ def search(results, lang, siteNum, search):
         if date:
             releaseDate = parse(date).strftime('%Y-%m-%d')
         else:
-            releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+            releaseDate = searchData.dateFormat() if searchData.date else ''
         displayDate = releaseDate if date else ''
 
-        if search['date'] and displayDate:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date and displayDate:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteDesperateAmateurs.py
+++ b/Contents/Code/siteDesperateAmateurs.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
 
     for searchResult in searchResults.xpath('//div[@align="left"]'):
@@ -15,10 +15,10 @@ def search(results, lang, siteNum, search):
 
         curID = PAutils.Encode(link.xpath('./@href')[0])
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [Desperate Amateurs] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteDickDrainers.py
+++ b/Contents/Code/siteDickDrainers.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].replace(' ', '+').lower()
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.replace(' ', '+').lower()
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
 
     for searchResult in searchResults.xpath('//div[@class="item-video hover"]'):
@@ -16,12 +16,12 @@ def search(results, lang, siteNum, search):
         if date:
             releaseDate = parse(date).strftime('%Y-%m-%d')
         else:
-            releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+            releaseDate = searchData.dateFormat() if searchData.date else ''
 
-        if search['date'] and releaseDate:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date and releaseDate:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteDorcelClub.py
+++ b/Contents/Code/siteDorcelClub.py
@@ -2,15 +2,15 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     # Scenes by name
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="scenes list"]/div[@class="items"]/div[@class="scene thumbnail "]'):
         titleNoFormatting = searchResult.xpath('.//div[@class="textual"]/a')[0].text_content().strip()
         curID = PAutils.Encode(searchResult.xpath('.//a[@class="title"]/@href')[0])
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 
@@ -19,7 +19,7 @@ def search(results, lang, siteNum, search):
         titleNoFormatting = searchResult.xpath('./h2')[0].text_content().strip()
         movieLink = searchResult.xpath('./@href')[0]
         curID = PAutils.Encode(movieLink)
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s - Full Movie [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 
@@ -30,7 +30,7 @@ def search(results, lang, siteNum, search):
             titleNoFormatting = movieScene.xpath('.//div[@class="textual"]/a')[0].text_content().strip()
             curID = curID = PAutils.Encode(movieScene.xpath('.//a[@class="title"]/@href')[0])
 
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 

--- a/Contents/Code/siteDorcelVision.py
+++ b/Contents/Code/siteDorcelVision.py
@@ -2,14 +2,14 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//a[contains(@class, "movies")]'):
         titleNoFormatting = searchResult.xpath('.//img/@alt')[0].strip()
         curID = PAutils.Encode(searchResult.get('href'))
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 

--- a/Contents/Code/siteElegantAngel.py
+++ b/Contents/Code/siteElegantAngel.py
@@ -2,14 +2,14 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="list-page-grid-container"]//div[@class="grid-item"]'):
         titleNoFormatting = searchResult.xpath('.//span[@class="overlay-inner"]')[0].text_content().strip()
         curID = PAutils.Encode(searchResult.xpath('.//a[@class="boxcover"]/@href')[0])
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [Elegant Angel]' % titleNoFormatting, score=score, lang=lang))
 

--- a/Contents/Code/siteExpliciteArt.py
+++ b/Contents/Code/siteExpliciteArt.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].replace(' ', '-').lower()
-    searchURL = '%s%s/page1.html' % (PAsearchSites.getSearchSearchURL(siteNum), search['encoded'])
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.replace(' ', '-').lower()
+    searchURL = '%s%s/page1.html' % (PAsearchSites.getSearchSearchURL(siteNum), searchData.encoded)
     req = PAutils.HTTPRequest(searchURL)
     searchResults = HTML.ElementFromString(req.text)
 
@@ -13,7 +13,7 @@ def search(results, lang, siteNum, search):
         sceneURL = searchResult.xpath('.//a/@href')[0]
         curID = PAutils.Encode(sceneURL)
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 

--- a/Contents/Code/siteFemjoy.py
+++ b/Contents/Code/siteFemjoy.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    searchURL = PAsearchSites.getSearchSearchURL(siteNum) + search['encoded']
+def search(results, lang, siteNum, searchData):
+    searchURL = PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded
     req = PAutils.HTTPRequest(searchURL)
     searchResults = req.json()
 
@@ -12,24 +12,24 @@ def search(results, lang, siteNum, search):
         # try to extract as much of the title as possible without including the model
         m = re.search(r'femjoy\.(\d{2}\.\d{2}\.\d{2})\.(.+)', filename, re.IGNORECASE)
         if m:
-            search['date'] = parse('20' + m.group(1)).strftime('%Y-%m-%d')
+            searchData.date = parse('20' + m.group(1)).strftime('%Y-%m-%d')
             searchWords = m.group(2).split('.')
             wordCount = len(searchWords)
             if wordCount > 2:
-                search['title'] = ' '.join(searchWords[2:])
+                searchData.title = ' '.join(searchWords[2:])
             else:
-                search['title'] = searchWords[-1]
+                searchData.title = searchWords[-1]
 
         else:
             # Belinda & Fiva - Give me your hand 29-Mar-2010.mp4
             # take everything from after the dash and before the date
             m = re.search(r'.+ - (.+) (\d{2}-[a-z]{3}-\d{4})', filename, re.IGNORECASE)
             if m:
-                search['date'] = parse(m.group(2)).strftime('%Y-%m-%d')
-                search['title'] = m.group(1)
+                searchData.date = parse(m.group(2)).strftime('%Y-%m-%d')
+                searchData.title = m.group(1)
 
-        search['encoded'] = urllib.quote(search['title'])
-        searchURL = PAsearchSites.getSearchSearchURL(siteNum) + search['encoded']
+        searchData.encoded = urllib.quote(searchData.title)
+        searchURL = PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded
         req = PAutils.HTTPRequest(searchURL)
         searchResults = req.json()
 
@@ -44,16 +44,16 @@ def search(results, lang, siteNum, search):
             if date:
                 releaseDate = parse(date).strftime('%Y-%m-%d')
             else:
-                releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+                releaseDate = searchData.dateFormat() if searchData.date else ''
             displayDate = releaseDate if date else ''
 
             actorsName = [actorLink['name'] for actorLink in searchResult['actors']]
             actorsString = getActorsString(actorsName)
 
-            if search['date'] and displayDate:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date and displayDate:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d|%d' % (curID, siteNum, sceneID), name='%s - %s [%s] %s' % (titleNoFormatting, actorsString, PAsearchSites.getSearchSiteName(siteNum), displayDate), score=score, lang=lang))
 

--- a/Contents/Code/siteFemjoy.py
+++ b/Contents/Code/siteFemjoy.py
@@ -7,10 +7,10 @@ def search(results, lang, siteNum, searchData):
     req = PAutils.HTTPRequest(searchURL)
     searchResults = req.json()
 
-    if 'results' not in searchResults or not searchResults['results'] and filename:
+    if 'results' not in searchResults or not searchResults['results'] and searchData.filename:
         # femjoy.17.03.12.maria.rya.girl.in.the.mirror.mp4
         # try to extract as much of the title as possible without including the model
-        m = re.search(r'femjoy\.(\d{2}\.\d{2}\.\d{2})\.(.+)', filename, re.IGNORECASE)
+        m = re.search(r'femjoy\.(\d{2}\.\d{2}\.\d{2})\.(.+)', searchData.filename, re.IGNORECASE)
         if m:
             searchData.date = parse('20' + m.group(1)).strftime('%Y-%m-%d')
             searchWords = m.group(2).split('.')
@@ -23,7 +23,7 @@ def search(results, lang, siteNum, searchData):
         else:
             # Belinda & Fiva - Give me your hand 29-Mar-2010.mp4
             # take everything from after the dash and before the date
-            m = re.search(r'.+ - (.+) (\d{2}-[a-z]{3}-\d{4})', filename, re.IGNORECASE)
+            m = re.search(r'.+ - (.+) (\d{2}-[a-z]{3}-\d{4})', searchData.filename, re.IGNORECASE)
             if m:
                 searchData.date = parse(m.group(2)).strftime('%Y-%m-%d')
                 searchData.title = m.group(1)

--- a/Contents/Code/siteFinishesTheJob.py
+++ b/Contents/Code/siteFinishesTheJob.py
@@ -2,13 +2,13 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="scene"]'):
         titleNoFormatting = searchResult.xpath('.//h4[@itemprop="name"]//a')[0].text_content()
         curID = PAutils.Encode(searchResult.xpath('.//a/@href')[0])
-        releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+        releaseDate = searchData.dateFormat() if searchData.date else ''
 
         subSite = searchResult.xpath('.//small[@class="shadow"]//a')[0].text_content().strip()
         if subSite.lower().replace('.com', '').replace(' ', '') == PAsearchSites.getSearchSiteName(siteNum).lower().replace(' ', ''):
@@ -16,7 +16,7 @@ def search(results, lang, siteNum, search):
         else:
             siteScore = 0
 
-        score = siteScore + 90 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = siteScore + 90 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s]' % (titleNoFormatting, subSite), score=score, lang=lang))
 

--- a/Contents/Code/siteFirstAnalQuest.py
+++ b/Contents/Code/siteFirstAnalQuest.py
@@ -2,18 +2,18 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//li[@class="thumb"]'):
         titleNoFormatting = searchResult.xpath('.//span[@class="thumb-title"]')[0].text_content().strip()
         curID = PAutils.Encode(searchResult.xpath('.//a[@class="thumb-img"]/@href')[0])
         releaseDate = parse(searchResult.xpath('.//span[@class="thumb-added"]')[0].text_content().strip()).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteFittingRoom.py
+++ b/Contents/Code/siteFittingRoom.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    sceneID = search['title'].split(' ', 1)[0]
+def search(results, lang, siteNum, searchData):
+    sceneID = searchData.title.split(' ', 1)[0]
     try:
-        sceneTitle = search['title'].split(' ', 1)[1]
+        sceneTitle = searchData.title.split(' ', 1)[1]
     except:
         sceneTitle = ''
 
@@ -14,10 +14,10 @@ def search(results, lang, siteNum, search):
     detailsPageElements = HTML.ElementFromString(req.text)
     titleNoFormatting = detailsPageElements.xpath('//title')[0].text_content().split('|')[1].strip()
     curID = PAutils.Encode(sceneURL)
-    releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+    releaseDate = searchData.dateFormat() if searchData.date else ''
 
     if sceneTitle:
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
     else:
         score = 90
 

--- a/Contents/Code/siteFuckingAwesome.py
+++ b/Contents/Code/siteFuckingAwesome.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="gallery"]/div'):
         titleNoFormatting = searchResult.xpath('.//div[@class="video-title truncate"]/a')[0].text_content().strip()
@@ -11,10 +11,10 @@ def search(results, lang, siteNum, search):
         releaseDate = parse(searchResult.xpath('.//span[@class="small date"]')[0].text_content().strip()).strftime('%Y-%m-%d')
         firstActor = searchResult.xpath('.//span[@class="subtitle small"]/a')[0].text_content().strip()
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s %s in %s [FuckingAwesome]' % (releaseDate, firstActor, titleNoFormatting), score=score, lang=lang))
 

--- a/Contents/Code/siteGangbangCreampie.py
+++ b/Contents/Code/siteGangbangCreampie.py
@@ -2,18 +2,18 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//li[@class="featured-video morestdimage grid_4 mb"]'):
         titleNoFormatting = searchResult.xpath('.//div[@class="details"]/h5/a')[0].text_content().strip()
         curID = PAutils.Encode(searchResult.xpath('.//div[@class="details"]/h5/a/@href')[0])
         releaseDate = parse(searchResult.xpath('.//div[@class="details"]/p/strong')[0].text_content().strip()).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [Gangbang Creampie] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteGirlsOutWest.py
+++ b/Contents/Code/siteGirlsOutWest.py
@@ -2,12 +2,12 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].lower().replace(' ', '-')
-    directURL = PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'] + '.html'
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.lower().replace(' ', '-')
+    directURL = PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded + '.html'
 
     searchResults = [directURL]
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         if '/trailers/' in sceneURL and sceneURL not in searchResults:
             searchResults.append(sceneURL)
@@ -22,10 +22,10 @@ def search(results, lang, siteNum, search):
             date = detailsPageElements.xpath('//div[@class="trailer topSpace"]/div[2]/p')[0].text_content().split('\\')[1].strip()
             releaseDate = parse(date).strftime('%Y-%m-%d')
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'], titleNoFormatting)
+                score = 100 - Util.LevenshteinDistance(searchData.title, titleNoFormatting)
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [GirlsOutWest] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteGirlsRimming.py
+++ b/Contents/Code/siteGirlsRimming.py
@@ -2,11 +2,11 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    directURL = '%s%s.html' % (PAsearchSites.getSearchSearchURL(siteNum), search['title'].lower().replace(' ', '-'))
+def search(results, lang, siteNum, searchData):
+    directURL = '%s%s.html' % (PAsearchSites.getSearchSearchURL(siteNum), searchData.title.lower().replace(' ', '-'))
     searchResults = [directURL]
 
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         sceneURL = sceneURL.lower()
         if ('/trailers/' in sceneURL) and sceneURL not in searchResults:
@@ -19,9 +19,9 @@ def search(results, lang, siteNum, search):
 
             titleNoFormatting = searchResult.xpath('//h2[@class="title"]/text()')[0]
             curID = PAutils.Encode(sceneURL)
-            releaseDate = parse(search['date']) if search['date'] else ''
+            releaseDate = parse(searchData.date) if searchData.date else ''
 
-            score = 100 - Util.LevenshteinDistance(search['title'], titleNoFormatting)
+            score = 100 - Util.LevenshteinDistance(searchData.title, titleNoFormatting)
 
             results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [Girls Rimming]' % titleNoFormatting, score=score, lang=lang))
 

--- a/Contents/Code/siteGloryHoleSecrets.py
+++ b/Contents/Code/siteGloryHoleSecrets.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//li[@class="featured-video morestdimage grid_4 mb"]'):
         detailsPage = searchResult.xpath('./a/@href')[0]
@@ -11,10 +11,10 @@ def search(results, lang, siteNum, search):
         releaseDate = parse(searchResult.xpath('./div[@class="details"]/p/strong')[0].text_content().strip()).strftime('%Y-%m-%d')
         curID = PAutils.Encode(detailsPage)
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [GloryHoleSecrets] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteHegre.py
+++ b/Contents/Code/siteHegre.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['encoded'] + '&year=' + parse(search['date']).strftime('%Y') if search['date'] else search['encoded']
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.encoded + '&year=' + parse(searchData.date).strftime('%Y') if searchData.date else searchData.encoded
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[contains(@class, "item")]'):
         sceneURL = searchResult.xpath('.//a/@href')[0]
@@ -13,10 +13,10 @@ def search(results, lang, siteNum, search):
             titleNoFormatting = searchResult.xpath('.//img/@alt')[0].strip()
             releaseDate = parse(searchResult.xpath('.//div[@class="details"]/span[last()]')[0].text_content().strip()).strftime('%Y-%m-%d')
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteHollyRandall.py
+++ b/Contents/Code/siteHollyRandall.py
@@ -4,8 +4,8 @@ import PAutils
 joinstr = 'https://join.hollyrandall.com/'
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[contains(@class, "item-video")]'):
         titleNoFormatting = searchResult.xpath('./div[@class="item-thumb"]/a/@title')[0]
@@ -17,7 +17,7 @@ def search(results, lang, siteNum, search):
             date = searchResult.xpath('./div[@class="timeDate"]')[0].text_content().split('|')[1].strip()
             releaseDate = parse(date).strftime('%Y-%m-%d') if date else ''
 
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
             results.Append(MetadataSearchResult(id='%s|%d|%s|%s' % (curID, siteNum, titleNoFormatting, releaseDate), name='%s %s [%s]' % (titleNoFormatting, releaseDate, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 
     return results

--- a/Contents/Code/siteHoloGirlsVR.py
+++ b/Contents/Code/siteHoloGirlsVR.py
@@ -2,34 +2,34 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    sceneID = search['title'].split(' ', 1)[0]
+def search(results, lang, siteNum, searchData):
+    sceneID = searchData.title.split(' ', 1)[0]
     if unicode(sceneID, 'UTF-8').isdigit():
-        search['title'] = search['title'].replace(sceneID, '', 1).strip()
+        searchData.title = searchData.title.replace(sceneID, '', 1).strip()
     else:
         sceneID = None
 
-    if sceneID and not search['title']:
+    if sceneID and not searchData.title:
         sceneURL = '%s/Scenes/Videos/%s' % (PAsearchSites.getSearchBaseURL(siteNum), sceneID)
         req = PAutils.HTTPRequest(sceneURL)
         searchResults = HTML.ElementFromString(req.text)
 
         titleNoFormatting = searchResults.xpath('//div[@class="col-xs-12 video-title"]//h3')[0].text_content().strip()
         curID = PAutils.Encode(sceneURL)
-        releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+        releaseDate = searchData.dateFormat() if searchData.date else ''
 
         score = 100
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
     else:
-        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
         searchResults = HTML.ElementFromString(req.text)
         for searchResult in searchResults.xpath('//div[@class="memVid"]'):
             titleNoFormatting = searchResult.xpath('.//div[@class="memVidTitle"]//a/@title')[0]
             curID = PAutils.Encode(searchResult.xpath('.//div[@class="memVidTitle"]//a/@href')[0])
-            releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+            releaseDate = searchData.dateFormat() if searchData.date else ''
 
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 

--- a/Contents/Code/siteHucows.py
+++ b/Contents/Code/siteHucows.py
@@ -2,13 +2,13 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    if search['date']:
-        search['encoded'] = parse(search['date']).strftime('%Y/%m')
+def search(results, lang, siteNum, searchData):
+    if searchData.date:
+        searchData.encoded = parse(searchData.date).strftime('%Y/%m')
     else:
-        search['encoded'] = '?s=%s' % search['title'].replace(' ', '+')
+        searchData.encoded = '?s=%s' % searchData.title.replace(' ', '+')
 
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//article'):
         sceneURL = searchResult.xpath('.//a/@href')[1].strip()
@@ -18,10 +18,10 @@ def search(results, lang, siteNum, search):
         date = searchResult.xpath('.//div[@itemprop="datePublished"]')[0].text_content().strip()
         releaseDate = parse(date).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         sceneID = 'N/A'
         imgNode = searchResult.xpath('.//img/@src')

--- a/Contents/Code/siteInTheCrack.py
+++ b/Contents/Code/siteInTheCrack.py
@@ -3,27 +3,27 @@ import PAutils
 import string
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     sceneID = ''
     all = string.maketrans('', '')
     nodigs = all.translate(all, string.digits)
 
     try:
-        sceneTitle = search['title'].split(' ', 2)[0]
+        sceneTitle = searchData.title.split(' ', 2)[0]
         sceneID = sceneTitle.translate(all, nodigs)
         if sceneID != '':
-            search['title'] = search['title'].split(' ', 2)[1]
+            searchData.title = searchData.title.split(' ', 2)[1]
 
-        search['title'] = search['title'].lower()
+        searchData.title = searchData.title.lower()
     except:
         pass
 
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['title'][0])
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.title[0])
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//ul[@class="collectionGridLayout"]/li'):
         discoveredname = searchResult.xpath('.//span')[0].text_content().strip().lower()
 
-        if search['title'] in discoveredname:
+        if searchData.title in discoveredname:
             modellink = searchResult.xpath('.//a/@href')[0]
             req = PAutils.HTTPRequest(PAsearchSites.getSearchBaseURL(siteNum) + modellink)
             searchResults = HTML.ElementFromString(req.text)

--- a/Contents/Code/siteInterracialPass.py
+++ b/Contents/Code/siteInterracialPass.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['title'].replace(' ', '+'))
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.title.replace(' ', '+'))
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[contains(@class, "item-video")]'):
         titleNoFormatting = searchResult.xpath('.//a/@title')[0]
@@ -11,10 +11,10 @@ def search(results, lang, siteNum, search):
         date = searchResult.xpath('.//div[@class="more-info-div"]')[0].text_content().split('|')
         releaseDate = parse(date[-1].strip()).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [InterracialPass] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteJacquieEtMichel.py
+++ b/Contents/Code/siteJacquieEtMichel.py
@@ -2,13 +2,13 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     sceneID = None
-    splited = search['title'].split()
-    if unicode(splited[0], 'UTF-8').isdigit():
-        sceneID = splited[0]
+    parts = searchData.title.split()
+    if unicode(parts[0], 'UTF-8').isdigit():
+        sceneID = parts[0]
 
-    url = PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'] + '.html'
+    url = PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded + '.html'
     req = PAutils.HTTPRequest(url)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[contains(@class, "video-item") and @data-get-thumbs-url]'):
@@ -17,10 +17,10 @@ def search(results, lang, siteNum, search):
         date = searchResult.xpath('.//div[@class="infos-video"]/p')[0].text_content().replace('Added on', '').strip()
         releaseDate = parse(date).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteJaysPOV.py
+++ b/Contents/Code/siteJaysPOV.py
@@ -2,14 +2,14 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="grid-item"]'):
         titleNoFormatting = searchResult.xpath('.//a[@class="grid-item-title"]/text()')[0]
         curID = PAutils.Encode(searchResult.xpath('.//a[@class="grid-item-title"]/@href')[0])
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name=titleNoFormatting, score=score, lang=lang))
 

--- a/Contents/Code/siteJoymii.py
+++ b/Contents/Code/siteJoymii.py
@@ -2,19 +2,19 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['encoded'].replace(' ', '+')
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.encoded.replace(' ', '+')
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[contains(@class, "set set-photo")]'):
         titleNoFormatting = searchResult.xpath('.//div[contains(@class, "title")]//a')[0].text_content().title().strip()
         curID = PAutils.Encode(searchResult.xpath('.//a/@href')[0])
         releaseDate = parse(searchResult.xpath('.//div[contains(@class, "release_date")]')[0].text_content().strip()).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteJulesJordan.py
+++ b/Contents/Code/siteJulesJordan.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="update_details"]'):
         curID = PAutils.Encode(searchResult.xpath('./a[last()]/@href')[0])
@@ -19,10 +19,10 @@ def search(results, lang, siteNum, search):
         if releaseDate:
             releaseDate = parse(releaseDate).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 

--- a/Contents/Code/siteKarups.py
+++ b/Contents/Code/siteKarups.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].replace(' ', '-')
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'] + '/')
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.replace(' ', '-')
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded + '/')
     actressearchResults = HTML.ElementFromString(req.text)
 
     actressPageUrl = actressearchResults.xpath('//div[@class="item-inside"]//a/@href')[0]
@@ -23,10 +23,10 @@ def search(results, lang, siteNum, search):
         elif subSiteRaw == 'kpc':
             subSite = 'KarupsPC'
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(titleNoFormatting.lower(), search['title'].lower())
+            score = 100 - Util.LevenshteinDistance(titleNoFormatting.lower(), searchData.title.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, subSite, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteLegalPorno.py
+++ b/Contents/Code/siteLegalPorno.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     if 'Search for' in searchResults.xpath('//title/text()')[0]:
         for searchResult in searchResults.xpath('//div[@class="thumbnails"]/div'):
@@ -11,10 +11,10 @@ def search(results, lang, siteNum, search):
             titleNoFormatting = searchResult.xpath('.//div[contains(@class, "thumbnail-title")]//a/@title')[0]
             releaseDate = parse(searchResult.xpath('./@release')[0]).strftime('%Y-%m-%d')
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
     else:

--- a/Contents/Code/siteLethalHardcoreVR.py
+++ b/Contents/Code/siteLethalHardcoreVR.py
@@ -2,18 +2,18 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="grid-item scene-list-item"]'):
         curID = PAutils.Encode(searchResult.xpath('.//a/@href')[0])
         titleNoFormatting = searchResult.xpath('.//p[contains(@class, "grid-item-title")]//span')[0].text_content().strip()
         releaseDate = parse(searchResult.xpath('.//p[@class="scene-update-stats"]//span')[1].text_content().strip()).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 

--- a/Contents/Code/siteLittleCaprice.py
+++ b/Contents/Code/siteLittleCaprice.py
@@ -2,18 +2,18 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@id="left-area"]/article'):
         titleNoFormatting = searchResult.xpath('.//h2[@class="entry-title"]/a')[0].text_content().strip()
         curID = PAutils.Encode(searchResult.xpath('.//h2[@class="entry-title"]/a/@href')[0])
         releaseDate = parse(searchResult.xpath('.//span[@class="published"]')[0].text_content().strip()).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [LittleCaprice] %s ' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteLoveHerFeet.py
+++ b/Contents/Code/siteLoveHerFeet.py
@@ -2,18 +2,18 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="item-video-overlay"]'):
         titleNoFormatting = searchResult.xpath('./a')[0].get('title').strip()
         curID = PAutils.Encode(searchResult.xpath('./a/@href')[0])
         releaseDate = parse(searchResult.xpath('.//p[@class="video-date"]')[0].text_content().strip()).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [Love Her Feet] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteLustReality.py
+++ b/Contents/Code/siteLustReality.py
@@ -2,11 +2,11 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    directURL = PAsearchSites.getSearchSearchURL(siteNum) + search['title'].replace(' ', '-').lower()
+def search(results, lang, siteNum, searchData):
+    directURL = PAsearchSites.getSearchSearchURL(siteNum) + searchData.title.replace(' ', '-').lower()
 
     searchResults = [directURL]
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         if ('/scene/' in sceneURL and sceneURL not in searchResults):
             searchResults.append(sceneURL)
@@ -21,10 +21,10 @@ def search(results, lang, siteNum, search):
             date = detailsPageElements.xpath('//span[@class="date-display-single"] | //span[@class="u-inline-block u-mr--nine"] | //div[@class="video-meta-date"] | //div[@class="date"]')[0].text_content().strip()
             releaseDate = parse(date).strftime('%Y-%m-%d')
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteManyvids.py
+++ b/Contents/Code/siteManyvids.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    sceneID = search['title'].split(' ', 1)[0]
+def search(results, lang, siteNum, searchData):
+    sceneID = searchData.title.split(' ', 1)[0]
     try:
-        sceneTitle = search['encoded'].split(' ', 1)[1]
+        sceneTitle = searchData.encoded.split(' ', 1)[1]
     except:
         sceneTitle = ''
 
@@ -13,9 +13,9 @@ def search(results, lang, siteNum, search):
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="video-details"]'):
         titleNoFormatting = searchResult.xpath('//h2[@class="h2 m-0"]')[0].text_content()
-        curID = search['title'].lower().replace(' ', '-')
+        curID = searchData.title.lower().replace(' ', '-')
         subSite = searchResult.xpath('//a[@class="username "]')[0].text_content().strip()
-        releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+        releaseDate = searchData.dateFormat() if searchData.date else ''
 
         if sceneTitle:
             score = 100 - Util.LevenshteinDistance(sceneTitle.lower(), titleNoFormatting.lower())

--- a/Contents/Code/siteMeanaWolf.py
+++ b/Contents/Code/siteMeanaWolf.py
@@ -2,15 +2,15 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="videoBlock"]'):
         titleNoFormatting = searchResult.xpath('./p/a')[0].text_content().strip()
         curID = PAutils.Encode(searchResult.xpath('./p/a/@href')[0])
         img = PAutils.Encode(searchResult.xpath('.//img[@class="video_placeholder"]/@src')[0])
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, img), name='%s [Meana Wolf]' % titleNoFormatting, score=score, lang=lang))
 

--- a/Contents/Code/siteMelenaMariaRya.py
+++ b/Contents/Code/siteMelenaMariaRya.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    sceneID = search['title'].split(' ', 1)[0]
+def search(results, lang, siteNum, searchData):
+    sceneID = searchData.title.split(' ', 1)[0]
     try:
-        sceneTitle = search['title'].split(' ', 1)[1]
+        sceneTitle = searchData.title.split(' ', 1)[1]
     except:
         sceneTitle = ''
 
@@ -17,7 +17,7 @@ def search(results, lang, siteNum, search):
     titleNoFormatting = re.sub(r'[^A-Za-z0-9\s\-]+', ' ', titleNoFormatting).strip()
 
     curID = PAutils.Encode(sceneURL)
-    releaseDate = search['date'] if search['date'] else ''
+    releaseDate = searchData.date if searchData.date else ''
 
     score = 100
 

--- a/Contents/Code/siteMeloneChallenge.py
+++ b/Contents/Code/siteMeloneChallenge.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     searchResults = []
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         if ('/video/' in sceneURL and sceneURL not in searchResults):
             searchResults.append(sceneURL)
@@ -15,9 +15,9 @@ def search(results, lang, siteNum, search):
 
         curID = PAutils.Encode(sceneURL)
         titleNoFormatting = detailsPageElements.xpath('.//a[@class="dark"]')[0].text_content().strip()
-        releaseDate = search['date'] if search['date'] else ''
+        releaseDate = searchData.date if searchData.date else ''
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 

--- a/Contents/Code/siteMilfVR.py
+++ b/Contents/Code/siteMilfVR.py
@@ -2,14 +2,14 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    sceneID = search['title'].split(' ', 1)[0]
+def search(results, lang, siteNum, searchData):
+    sceneID = searchData.title.split(' ', 1)[0]
     if unicode(sceneID, 'UTF-8').isdigit():
-        search['title'] = search['title'].replace(sceneID, '', 1).strip()
+        searchData.title = searchData.title.replace(sceneID, '', 1).strip()
     else:
         sceneID = None
 
-    if sceneID and not search['title']:
+    if sceneID and not searchData.title:
         req = PAutils.HTTPRequest(PAsearchSites.getSearchBaseURL(siteNum) + '/' + sceneID, cookies={
             'sst': 'ulang-en'
         })
@@ -27,8 +27,8 @@ def search(results, lang, siteNum, search):
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='[%s] %s %s' % (PAsearchSites.getSearchSiteName(siteNum), titleNoFormatting, releaseDate), score=score, lang=lang))
     else:
-        search['encoded'] = search['title'].replace(' ', '+')
-        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'], cookies={
+        searchData.encoded = searchData.title.replace(' ', '+')
+        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded, cookies={
             'sst': 'ulang-en'
         })
         searchResults = HTML.ElementFromString(req.text)
@@ -37,10 +37,10 @@ def search(results, lang, siteNum, search):
             curID = PAutils.Encode(searchResult.xpath('.//a/@href')[0])
             releaseDate = parse(searchResult.xpath('.//div[@class="card__date"]')[0].text_content().strip()).strftime('%Y-%m-%d')
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteMissaX.py
+++ b/Contents/Code/siteMissaX.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="updateItem"] | //div[@class="photo-thumb video-thumb"]'):
         titleNoFormatting = searchResult.xpath('.//h4//a | .//p[@class="thumb-title"]')[0].text_content().strip()
@@ -19,10 +19,10 @@ def search(results, lang, siteNum, search):
         if firstActor:
             displayName = '%s + %d in %s' % (firstActor, numActors, displayName)
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name=displayName, score=score, lang=lang))
 

--- a/Contents/Code/siteMomPOV.py
+++ b/Contents/Code/siteMomPOV.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@id="inner_content"]/div[@class="entry"]'):
         titleNoFormatting = searchResult.xpath('.//div[@class="title_holder"]/h1/a')[0].text_content().strip()
@@ -15,10 +15,10 @@ def search(results, lang, siteNum, search):
         date = '-'.join((month, day, year))
         releaseDate = parse(date).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [MomPOV] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteMormonGirlz.py
+++ b/Contents/Code/siteMormonGirlz.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    url = PAsearchSites.getSearchSearchURL(siteNum) + search['encoded']
+def search(results, lang, siteNum, searchData):
+    url = PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded
     req = PAutils.HTTPRequest(url)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//*[contains(@class, " post ")]'):
@@ -13,10 +13,10 @@ def search(results, lang, siteNum, search):
         date = searchResult.xpath('.//time[@class="entry-date"]/@datetime')[0].strip()
         releaseDate = parse(date).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [MormonGirlz] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteMylf.py
+++ b/Contents/Code/siteMylf.py
@@ -12,8 +12,8 @@ def getJSONfromPage(url):
     return None
 
 
-def search(results, lang, siteNum, search):
-    directURL = search['title'].replace(' ', '-').lower()
+def search(results, lang, siteNum, searchData):
+    directURL = searchData.title.replace(' ', '-').lower()
     if '/' not in directURL:
         directURL = directURL.replace('-', '/', 1)
 
@@ -27,7 +27,7 @@ def search(results, lang, siteNum, search):
     directURL = PAsearchSites.getSearchSearchURL(siteNum) + directURL
     searchResultsURLs = [directURL]
 
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
 
     for sceneURL in googleResults:
         sceneURL = sceneURL.rsplit('?', 1)[0]
@@ -58,13 +58,13 @@ def search(results, lang, siteNum, search):
                 if 'publishedDate' in detailsPageElements:
                     releaseDate = parse(detailsPageElements['publishedDate']).strftime('%Y-%m-%d')
                 else:
-                    releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+                    releaseDate = searchData.dateFormat() if searchData.date else ''
                 displayDate = releaseDate if 'publishedDate' in detailsPageElements else ''
 
-                if search['date'] and displayDate:
-                    score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+                if searchData.date and displayDate:
+                    score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
                 else:
-                    score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                    score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
                 results.Append(MetadataSearchResult(id='%s|%d|%s|%s' % (curID, siteNum, releaseDate, contentName), name='%s [Mylf/%s] %s' % (titleNoFormatting, subSite, displayDate), score=score, lang=lang))
 

--- a/Contents/Code/siteNaughtyAmerica.py
+++ b/Contents/Code/siteNaughtyAmerica.py
@@ -12,18 +12,18 @@ def getAlgolia(url, indexName, params):
     return data['results'][0]['hits']
 
 
-def search(results, lang, siteNum, search):
-    sceneID = search['title'].split(' ', 1)[0]
+def search(results, lang, siteNum, searchData):
+    sceneID = searchData.title.split(' ', 1)[0]
     if unicode(sceneID, 'UTF-8').isdigit():
-        search['title'] = search['title'].replace(sceneID, '', 1).strip()
+        searchData.title = searchData.title.replace(sceneID, '', 1).strip()
     else:
         sceneID = None
 
     url = PAsearchSites.getSearchSearchURL(siteNum) + '?x-algolia-application-id=I6P9Q9R18E&x-algolia-api-key=08396b1791d619478a55687b4deb48b4'
-    if sceneID and not search['title']:
+    if sceneID and not searchData.title:
         searchResults = getAlgolia(url, 'nacms_scenes_production', 'filters=id=' + sceneID)
     else:
-        searchResults = getAlgolia(url, 'nacms_scenes_production', 'query=' + search['title'])
+        searchResults = getAlgolia(url, 'nacms_scenes_production', 'query=' + searchData.title)
 
     for searchResult in searchResults:
         titleNoFormatting = searchResult['title']
@@ -33,10 +33,10 @@ def search(results, lang, siteNum, search):
 
         if sceneID:
             score = 100 - Util.LevenshteinDistance(sceneID, curID)
-        elif search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        elif searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%d|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, siteName, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteNewSensations.py
+++ b/Contents/Code/siteNewSensations.py
@@ -2,15 +2,15 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].replace(' ', '-')
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.replace(' ', '-')
     searchResultsURLs = [
-        PAsearchSites.getSearchSearchURL(siteNum) + 'updates/' + search['encoded'] + '.html',
-        PAsearchSites.getSearchSearchURL(siteNum) + 'updates/' + search['encoded'] + '-.html',
-        PAsearchSites.getSearchSearchURL(siteNum) + 'dvds/' + search['encoded'] + '.html'
+        PAsearchSites.getSearchSearchURL(siteNum) + 'updates/' + searchData.encoded + '.html',
+        PAsearchSites.getSearchSearchURL(siteNum) + 'updates/' + searchData.encoded + '-.html',
+        PAsearchSites.getSearchSearchURL(siteNum) + 'dvds/' + searchData.encoded + '.html'
     ]
 
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         if sceneURL not in searchResultsURLs:
             if (('/updates/' in sceneURL or '/dvds/' in sceneURL or '/scenes/' in sceneURL) and '/tour_ns/' in sceneURL) and sceneURL not in searchResultsURLs:
@@ -25,7 +25,7 @@ def search(results, lang, siteNum, search):
                 titleNoFormatting = searchResult.xpath('(//div[@class="indScene"] | //div[@class="indSceneDVD"])/h2')[0].text_content().strip()
                 curID = PAutils.Encode(sceneURL)
 
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
                 results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [New Sensations]' % titleNoFormatting, score=score, lang=lang))
             except:

--- a/Contents/Code/siteNewSensationsOther.py
+++ b/Contents/Code/siteNewSensationsOther.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['encoded'].replace(' ', '+').lower()
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.encoded.replace(' ', '+').lower()
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
 
     for searchResult in searchResults.xpath('//div[@class="update_details"]'):
@@ -18,10 +18,10 @@ def search(results, lang, siteNum, search):
         except:
             releaseDate = ''
 
-        if search['date'] and releaseDate:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date and releaseDate:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/sitePJGirls.py
+++ b/Contents/Code/sitePJGirls.py
@@ -2,18 +2,18 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="thumb video"]'):
         titleNoFormatting = searchResult.xpath('./h2')[0].text_content().title().strip()
         curID = PAutils.Encode(searchResult.xpath('./a/@href')[0])
         releaseDate = parse(searchResult.xpath('./a/div/span[2]')[0].text_content().strip()).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [PJGirls] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/sitePenthouseGold.py
+++ b/Contents/Code/sitePenthouseGold.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="scene"]'):
         url = searchResult.xpath('.//a[@data-track="TITLE_LINK"]/@href')[0]
@@ -12,15 +12,15 @@ def search(results, lang, siteNum, search):
             titleNoFormatting = searchResult.xpath('.//a[@data-track="TITLE_LINK"]')[0].text_content()
             releaseDate = parse(searchResult.xpath('./span[@class="scene-date"]')[0].text_content().strip()).strftime('%Y-%m-%d')
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 
     # search for exact scene name
-    urlTitle = search['encoded'].replace('%20', '-')
+    urlTitle = searchData.encoded.replace('%20', '-')
     urls = [PAsearchSites.getSearchBaseURL(siteNum) + '/scenes/video---' + urlTitle + '_vids.html',
             PAsearchSites.getSearchBaseURL(siteNum) + '/scenes/movie---' + urlTitle + '_vids.html']
 

--- a/Contents/Code/sitePlayboyPlus.py
+++ b/Contents/Code/sitePlayboyPlus.py
@@ -2,18 +2,18 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    data = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + '/' + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    data = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + '/' + searchData.encoded)
     searchResults = HTML.ElementFromString(data.text)
     for searchResult in searchResults.xpath('//div[@id="search-results-gallery"]//li[@class="item"]'):
         titleNoFormatting = searchResult.xpath('.//h3[@class="title"]')[0].text_content().strip()
         releaseDate = parse(searchResult.xpath('.//p[@class="date"]')[0].text_content().strip()).strftime('%Y-%m-%d')
         img = PAutils.Encode(searchResults.xpath('.//img[contains(@class, "image")]/@data-src')[0].split('?', 1)[0])
         curID = PAutils.Encode(PAsearchSites.getSearchBaseURL(siteNum) + searchResult.xpath('.//a[@class="cardLink"]/@href')[0])
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, img), name='%s [Playboy Plus] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/sitePlumperPass.py
+++ b/Contents/Code/sitePlumperPass.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     searchResults = []
 
-    url = PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'] + '&sid=587'
+    url = PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded + '&sid=587'
     req = PAutils.HTTPRequest(url)
     siteSearchResults = HTML.ElementFromString(req.text)
     for searchResult in siteSearchResults.xpath('//div[@class="itemm"]'):
@@ -13,7 +13,7 @@ def search(results, lang, siteNum, search):
 
         searchResults.append(sceneURL)
 
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for result in googleResults:
         pattern = re.search(r'(?<=\dpp\/).*(?=\/)', result)
         if pattern:
@@ -35,13 +35,13 @@ def search(results, lang, siteNum, search):
             if date:
                 releaseDate = parse(date).strftime('%Y-%m-%d')
             else:
-                releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+                releaseDate = searchData.dateFormat() if searchData.date else ''
             displayDate = releaseDate if date else ''
 
-            if search['date'] and displayDate:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date and displayDate:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), displayDate), score=score, lang=lang))
 

--- a/Contents/Code/sitePorndoePremium.py
+++ b/Contents/Code/sitePorndoePremium.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[contains(@class, "main-content-videos")]//div[contains(@class, "card-video")]'):
         titleNoFormatting = searchResult.xpath('.//a/@aria-label')[0]
@@ -12,10 +12,10 @@ def search(results, lang, siteNum, search):
         date = searchResult.xpath('.//p[contains(@class, "extra-info") and not(contains(@class, "actors"))]')[0].text_content().strip()
         releaseDate = parse(date).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [LetsDoeIt/%s] %s' % (titleNoFormatting, subSite, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/sitePornstarPlatinum.py
+++ b/Contents/Code/sitePornstarPlatinum.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="item no-nth "]'):
         titleNoFormatting = searchResult.xpath('./div[@class="item-content"]/h3/a')[0].text_content()
@@ -20,7 +20,7 @@ def search(results, lang, siteNum, search):
             pass
         releaseDate = parse(date).strftime('%Y-%m-%d') if date else ''
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
         results.Append(MetadataSearchResult(id='%s|%d|%s|%s|%s|%s' % (curID, siteNum, titleNoFormatting, releaseDate, posterURL, actorname), name='%s %s [%s]' % (titleNoFormatting, releaseDate, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 
     return results

--- a/Contents/Code/sitePrivate.py
+++ b/Contents/Code/sitePrivate.py
@@ -2,15 +2,15 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//ul[@id="search_results"]//li[contains(@class, "col-sm-6")]'):
         titleNoFormatting = searchResult.xpath('.//div[@class="scene"]//div//h3//a')[0].text_content()
         curID = PAutils.Encode(searchResult.xpath('.//div[@class="scene"]//div//h3//a/@href')[0])
-        releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+        releaseDate = searchData.dateFormat() if searchData.date else ''
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [Private]' % titleNoFormatting, score=score, lang=lang))
 

--- a/Contents/Code/sitePurgatoryX.py
+++ b/Contents/Code/sitePurgatoryX.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     searchResults = []
 
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         sceneURL = sceneURL.split('?')[0].replace('dev.', '', 1)
 
@@ -27,10 +27,10 @@ def search(results, lang, siteNum, search):
                     date = searchResult.xpath('.//span[@class="pub-date"]')[0].text_content().strip()
                     releaseDate = parse(date).strftime('%Y-%m-%d')
 
-                    if search['date']:
-                        score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+                    if searchData.date:
+                        score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
                     else:
-                        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
                     results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 
@@ -44,10 +44,10 @@ def search(results, lang, siteNum, search):
         date = detailsPageElements.xpath('//span[@class="date"]')[0].text_content().strip()
         releaseDate = parse(date).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/sitePutalocura.py
+++ b/Contents/Code/sitePutalocura.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     searchResults = []
 
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum, lang='enes')
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum, lang='enes')
     for sceneURL in googleResults:
         sceneURL = sceneURL.replace('index.php/', '')
         sceneURL = sceneURL.replace('es/', '')
@@ -32,13 +32,13 @@ def search(results, lang, siteNum, search):
             if date:
                 releaseDate = datetime.strptime(date, '%d/%m/%Y').strftime('%Y-%m-%d')
             else:
-                releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+                releaseDate = searchData.dateFormat() if searchData.date else ''
             displayDate = releaseDate if date else ''
 
-            if search['date'] and displayDate:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date and displayDate:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s {%s} [%s] %s' % (titleNoFormatting, language, PAsearchSites.getSearchSiteName(siteNum), displayDate), score=score, lang=lang))
         except:

--- a/Contents/Code/siteQueenSnake.py
+++ b/Contents/Code/siteQueenSnake.py
@@ -11,10 +11,10 @@ import PAutils
 # - Add actor photos manually.
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].replace(' ', '-').lower()
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.replace(' ', '-').lower()
 
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'].lower() + '/', headers={'Cookie': 'cLegalAge=true'})
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded.lower() + '/', headers={'Cookie': 'cLegalAge=true'})
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="contentBlock"]'):
         titleNoFormatting = searchResult.xpath('.//span[@class="contentFilmName"]')[0].text_content().strip().title()
@@ -22,9 +22,9 @@ def search(results, lang, siteNum, search):
         date = searchResult.xpath('.//span[@class="contentFileDate"]')[0].text_content().strip().split(' • ')[0]
         releaseDate = parse(date).strftime('%Y-%m-%d')
 
-        curID = PAutils.Encode(search['encoded'].lower())
+        curID = PAutils.Encode(searchData.encoded.lower())
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         if '/previewmovies/0' not in str(searchResult.xpath('//div[@class="pagerWrapper"]/a/@href')[0]):
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))

--- a/Contents/Code/siteRealityLovers.py
+++ b/Contents/Code/siteRealityLovers.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     params = json.dumps({
         'sortBy': 'MOST_RELEVANT',
-        'searchQuery': search['title'],
+        'searchQuery': searchData.title,
         'videoView': 'MEDIUM'
     })
     req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum), params=params, headers={'Content-Type': 'application/json'})
@@ -17,10 +17,10 @@ def search(results, lang, siteNum, search):
         siteName = PAsearchSites.getSearchSiteName(siteNum)
         titleNoFormatting = '%s [%s] %s' % (searchResult['title'], siteName, releaseDate)
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, posterID), name=titleNoFormatting, score=score, lang=lang))
 

--- a/Contents/Code/siteReidMyLips.py
+++ b/Contents/Code/siteReidMyLips.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].lower().replace(' ', '-')
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.lower().replace(' ', '-')
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     detailsPageElements = HTML.ElementFromString(req.text)
 
     titleNoFormatting = detailsPageElements.xpath('//title')[0].text_content().split('|')[-1].strip()

--- a/Contents/Code/siteScrewMeToo.py
+++ b/Contents/Code/siteScrewMeToo.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].replace(' ', '+').replace('--', '+').lower()
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.replace(' ', '+').replace('--', '+').lower()
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="fsp  bor-r relative"]/article'):
         titleNoFormatting = searchResult.xpath('.//h4')[0].text_content().strip()
@@ -15,14 +15,14 @@ def search(results, lang, siteNum, search):
         if date:
             releaseDate = parse(date).strftime('%Y-%m-%d')
         else:
-            releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+            releaseDate = searchData.dateFormat() if searchData.date else ''
         releaseDate = parse(date).strftime('%Y-%m-%d')
         displayDate = releaseDate if date else ''
 
-        if search['date'] and displayDate:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date and displayDate:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteScrewbox.py
+++ b/Contents/Code/siteScrewbox.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="item"]'):
         titleNoFormatting = searchResult.xpath('.//h4//a')[0].text_content().strip()
@@ -11,7 +11,7 @@ def search(results, lang, siteNum, search):
         actors = searchResult.xpath('.//div[@class="item-featured"]//a')
         firstActor = actors[0].text_content().strip().title()
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s in %s [Screwbox]' % (firstActor, titleNoFormatting), score=score, lang=lang))
 

--- a/Contents/Code/siteSexLikeReal.py
+++ b/Contents/Code/siteSexLikeReal.py
@@ -2,11 +2,11 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    directURL = PAsearchSites.getSearchSearchURL(siteNum) + search['title'].replace(' ', '-').lower()
+def search(results, lang, siteNum, searchData):
+    directURL = PAsearchSites.getSearchSearchURL(siteNum) + searchData.title.replace(' ', '-').lower()
 
     searchResults = [directURL]
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         if ('/scenes/' in sceneURL and sceneURL not in searchResults):
             searchResults.append(sceneURL)
@@ -19,10 +19,10 @@ def search(results, lang, siteNum, search):
             titleNoFormatting = detailsPageElements.xpath('//h1')[0].text_content().strip()
             releaseDate = parse(detailsPageElements.xpath('//time/@datetime')[0]).strftime('%Y-%m-%d')
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteSexMex.py
+++ b/Contents/Code/siteSexMex.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].replace(' ', '+').lower()
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.replace(' ', '+').lower()
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
 
     for searchResult in searchResults.xpath('//div[@class="thumbnail"]'):
@@ -18,10 +18,10 @@ def search(results, lang, siteNum, search):
         except:
             releaseDate = ''
 
-        if search['date'] and releaseDate:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date and releaseDate:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteSicflics.py
+++ b/Contents/Code/siteSicflics.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    url = PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'] + '/page1.html'
+def search(results, lang, siteNum, searchData):
+    url = PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded + '/page1.html'
     req = PAutils.HTTPRequest(url)
     searchResults = HTML.ElementFromString(req.text)
 
@@ -26,13 +26,13 @@ def search(results, lang, siteNum, search):
         if date:
             releaseDate = parse(date).strftime('%Y-%m-%d')
         else:
-            releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+            releaseDate = searchData.dateFormat() if searchData.date else ''
         displayDate = releaseDate if date else ''
 
-        if search['date'] and displayDate:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date and displayDate:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%d|%d|%s|%s' % (curID, siteNum, description, imgURL), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), displayDate), score=score, lang=lang))
 

--- a/Contents/Code/siteSinsLife.py
+++ b/Contents/Code/siteSinsLife.py
@@ -2,14 +2,14 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[4]/div/div[3]/div/div'):
         titleNoFormatting = searchResult.xpath('.//a/@title')[0].title()
         curID = PAutils.Encode(searchResult.xpath('.//a/@href')[0])
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [SinsLife]' % titleNoFormatting, score=score, lang=lang))
 

--- a/Contents/Code/siteSpizoo.py
+++ b/Contents/Code/siteSpizoo.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="category_listing_wrapper_updates"]'):
         titleNoFormatting = searchResult.xpath('.//h3')[0].text_content().strip()
@@ -16,10 +16,10 @@ def search(results, lang, siteNum, search):
         except:
             releaseDate = ''
 
-        if search['date'] and releaseDate:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date and releaseDate:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [Spizoo] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteStepSecrets.py
+++ b/Contents/Code/siteStepSecrets.py
@@ -2,15 +2,15 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[contains(@class, "card-simple")]'):
         titleNoFormatting = searchResult.xpath('.//a[@class="color-title"]/text()')[0]
         curID = PAutils.Encode(searchResult.xpath('.//a/@href')[0])
-        releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+        releaseDate = searchData.dateFormat() if searchData.date else ''
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name=titleNoFormatting, score=score, lang=lang))
 

--- a/Contents/Code/siteStraplezz.py
+++ b/Contents/Code/siteStraplezz.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    url = PAsearchSites.getSearchSearchURL(siteNum) + search['title'].replace(' ', '-') + '.html'
+def search(results, lang, siteNum, searchData):
+    url = PAsearchSites.getSearchSearchURL(siteNum) + searchData.title.replace(' ', '-') + '.html'
     req = PAutils.HTTPRequest(url)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="card"]'):
@@ -11,10 +11,10 @@ def search(results, lang, siteNum, search):
         curID = PAutils.Encode(url)
         releaseDate = parse(searchResult.xpath('.//div[2]/div/div[1]/p[2]/small')[0].text_content().replace('Posted on', '').strip()).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [Straplezz] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteSunnyLaneLive.py
+++ b/Contents/Code/siteSunnyLaneLive.py
@@ -2,19 +2,19 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     sceneID = None
-    splited = search['title'].split()
-    if unicode(splited[0], 'UTF-8').isdigit():
-        sceneID = splited[0]
-        search['title'] = search['title'].replace(sceneID, '', 1).strip()
+    parts = searchData.title.split()
+    if unicode(parts[0], 'UTF-8').isdigit():
+        sceneID = parts[0]
+        searchData.title = searchData.title.replace(sceneID, '', 1).strip()
 
     searchResults = []
     if sceneID:
         directURL = PAsearchSites.getSearchSearchURL(siteNum) + sceneID
         searchResults.append(directURL)
 
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         sceneURL = re.sub(r'www\.', '', sceneURL)
         sceneURL = re.sub(r'/(?<=\d/).*', '', sceneURL)
@@ -34,10 +34,10 @@ def search(results, lang, siteNum, search):
         except:
             releaseDate = ''
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteTonightsGirlfriend.py
+++ b/Contents/Code/siteTonightsGirlfriend.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].lower().split('and ')[0].strip().replace(' ', '-')
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.lower().split('and ')[0].strip().replace(' ', '-')
     for page in range(1, 5):
-        req = PAutils.HTTPRequest('%s%s/?p=%d' % (PAsearchSites.getSearchSearchURL(siteNum), search['encoded'], page))
+        req = PAutils.HTTPRequest('%s%s/?p=%d' % (PAsearchSites.getSearchSearchURL(siteNum), searchData.encoded, page))
         searchResults = HTML.ElementFromString(req.text)
         for searchResult in searchResults.xpath('//div[@class="panel-body"]'):
             actorList = []
@@ -21,10 +21,10 @@ def search(results, lang, siteNum, search):
 
             releaseDate = parse(searchResult.xpath('.//span[@class="available-date"]')[0].text_content().strip()).strftime('%m-%d-%y')
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), firstActor.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), firstActor.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [Tonight\'s Girlfriend] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteToughLoveX.py
+++ b/Contents/Code/siteToughLoveX.py
@@ -2,13 +2,13 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].replace(' ', '-').lower()
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.replace(' ', '-').lower()
 
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['title'][:1])
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.title[:1])
     actorResults = HTML.ElementFromString(req.text)
 
-    actorPage = actorResults.xpath('//a[contains(@href, "%s")]/@href' % search['encoded'])[0]
+    actorPage = actorResults.xpath('//a[contains(@href, "%s")]/@href' % searchData.encoded)[0]
     req = PAutils.HTTPRequest(actorPage)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="content-box"]'):
@@ -16,9 +16,9 @@ def search(results, lang, siteNum, search):
         sceneURL = searchResult.xpath('.//a/@href')[0]
         curID = PAutils.Encode(sceneURL)
 
-        releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+        releaseDate = searchData.dateFormat() if searchData.date else ''
 
-        score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 

--- a/Contents/Code/siteTrueAmateurs.py
+++ b/Contents/Code/siteTrueAmateurs.py
@@ -2,10 +2,10 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    sceneID = search['title'].split(' ', 1)[0]
+def search(results, lang, siteNum, searchData):
+    sceneID = searchData.title.split(' ', 1)[0]
     try:
-        sceneTitle = search['title'].split(' ', 1)[1]
+        sceneTitle = searchData.title.split(' ', 1)[1]
     except:
         sceneTitle = ''
 

--- a/Contents/Code/siteTwoTGirls.py
+++ b/Contents/Code/siteTwoTGirls.py
@@ -3,8 +3,8 @@ import PAextras
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    sceneURL = PAsearchSites.getSearchBaseURL(siteNum) + '/video/' + search['title'].replace(' ', '-')
+def search(results, lang, siteNum, searchData):
+    sceneURL = PAsearchSites.getSearchBaseURL(siteNum) + '/video/' + searchData.title.replace(' ', '-')
     req = PAutils.HTTPRequest(sceneURL)
     if req.ok:
         detailsPageElements = HTML.ElementFromString(req.text)
@@ -12,21 +12,21 @@ def search(results, lang, siteNum, search):
 
         titleNoFormatting = detailsPageElements.xpath('.//h1')[0].text_content().strip()
         curID = PAutils.Encode(sceneURL)
-        releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+        releaseDate = searchData.dateFormat() if searchData.date else ''
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [TwoTGirls]' % titleNoFormatting, score=score, lang=lang))
     else:
-        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
         searchResults = HTML.ElementFromString(req.text)
         for searchResult in searchResults.xpath('//article'):
             sceneURL = searchResult.xpath('.//a/@href')[0]
             curID = PAutils.Encode(sceneURL)
             titleNoFormatting = searchResult.xpath('.//h2')[0].text_content().strip()
-            releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+            releaseDate = searchData.dateFormat() if searchData.date else ''
 
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [TwoTGirls]' % titleNoFormatting, score=score, lang=lang))
 

--- a/Contents/Code/siteUltrafilms.py
+++ b/Contents/Code/siteUltrafilms.py
@@ -3,8 +3,8 @@ import PAextras
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    url = PAsearchSites.getSearchSearchURL(siteNum) + '%22' + search['encoded'] + '%22'
+def search(results, lang, siteNum, searchData):
+    url = PAsearchSites.getSearchSearchURL(siteNum) + '%22' + searchData.encoded + '%22'
     maxscore = 0
 
     req = PAutils.HTTPRequest(url)
@@ -14,7 +14,7 @@ def search(results, lang, siteNum, search):
         actors = searchResult.xpath('.//img/@alt')[0]
         curID = PAutils.Encode(searchResult.xpath('.//a/@href')[0])
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s with %s [%s]' % (titleNoFormatting, actors, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 
@@ -22,7 +22,7 @@ def search(results, lang, siteNum, search):
             maxscore = score
 
     if maxscore < 100:
-        url = PAsearchSites.getSearchSearchURL(siteNum) + search['encoded']
+        url = PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded
         req = PAutils.HTTPRequest(url)
         searchResults = HTML.ElementFromString(req.text)
         for searchResult in searchResults.xpath('//ul[@class="listing-videos listing-tube"]/*[div[@class="format-infos"]/div[@class="time-infos"]]'):
@@ -30,7 +30,7 @@ def search(results, lang, siteNum, search):
             actors = searchResult.xpath('.//img/@alt')[0]
             curID = PAutils.Encode(searchResult.xpath('.//a/@href')[0])
 
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s with %s [%s]' % (titleNoFormatting, actors, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 

--- a/Contents/Code/siteVIPissy.py
+++ b/Contents/Code/siteVIPissy.py
@@ -2,15 +2,15 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@style="position:relative; background:black;"]'):
         titleNoFormatting = searchResult.xpath('.//a/@title')[0]
         curID = PAutils.Encode(searchResult.xpath('.//a/@href')[0])
         releaseDate = parse(searchResult.xpath('.//span[@class="date"]')[0].text_content().strip()).strftime('%Y-%m-%d')
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s VIPissy] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteVRBangers.py
+++ b/Contents/Code/siteVRBangers.py
@@ -2,14 +2,14 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//article'):
         titleNoFormatting = searchResult.xpath('.//a[@rel="bookmark"]')[0].text_content().strip()
         curID = PAutils.Encode(searchResult.xpath('.//a/@href')[0])
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         if len(titleNoFormatting) > 29:
             titleNoFormatting = titleNoFormatting[:32] + '...'

--- a/Contents/Code/siteVRConk.py
+++ b/Contents/Code/siteVRConk.py
@@ -2,11 +2,11 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    directURL = PAsearchSites.getSearchSearchURL(siteNum) + search['title'].replace(' ', '-').lower()
+def search(results, lang, siteNum, searchData):
+    directURL = PAsearchSites.getSearchSearchURL(siteNum) + searchData.title.replace(' ', '-').lower()
 
     searchResults = [directURL]
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         if ('/virtualreality/' in sceneURL and sceneURL not in searchResults and '/virtualreality/list' not in sceneURL):
             searchResults.append(sceneURL)
@@ -22,10 +22,10 @@ def search(results, lang, siteNum, search):
                 date = detailsPageElements.xpath('//div[@class="stats-container"]//li[3]//span[2]')[0].text_content().strip()
                 releaseDate = parse(date).strftime('%Y-%m-%d')
 
-                if search['date'] and releaseDate:
-                    score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+                if searchData.date and releaseDate:
+                    score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
                 else:
-                    score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                    score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
                 results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 

--- a/Contents/Code/siteVRHush.py
+++ b/Contents/Code/siteVRHush.py
@@ -2,17 +2,17 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].replace(' ', '_')
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.replace(' ', '_')
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     detailsPageElements = HTML.ElementFromString(req.text)
 
     titleNoFormatting = detailsPageElements.xpath('//h1[@class="latest-scene-title"]')[0].text_content().strip()
     curID = PAutils.Encode(detailsPageElements.xpath('//link[@rel="canonical"]/@href')[0])
     releaseDate = parse(detailsPageElements.xpath('//div[contains(@class, "latest-scene-meta")]//div[contains(@class, "text-left")]')[0].text_content().strip()).strftime('%Y-%m-%d')
 
-    if search['date']:
-        score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+    if searchData.date:
+        score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
     else:
         score = 95
 

--- a/Contents/Code/siteVRLatina.py
+++ b/Contents/Code/siteVRLatina.py
@@ -2,11 +2,11 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    directURL = PAsearchSites.getSearchSearchURL(siteNum) + search['title'].replace(' ', '-').lower() + '/'
+def search(results, lang, siteNum, searchData):
+    directURL = PAsearchSites.getSearchSearchURL(siteNum) + searchData.title.replace(' ', '-').lower() + '/'
 
     searchResults = [directURL]
-    googleResults = PAutils.getFromGoogleSearch(search['title'], siteNum)
+    googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for sceneURL in googleResults:
         if ('/video/' in sceneURL and sceneURL not in searchResults):
             searchResults.append(sceneURL)
@@ -21,10 +21,10 @@ def search(results, lang, siteNum, search):
             date = detailsPageElements.xpath('//div[@class="video-info-left-icon"]//span[3]/text()')[0].strip()
             releaseDate = datetime.strptime(date, '%d%b,%Y').strftime('%Y-%m-%d')
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 

--- a/Contents/Code/siteVRPFilms.py
+++ b/Contents/Code/siteVRPFilms.py
@@ -2,15 +2,15 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//article[contains(@class, "movie-column")]'):
         titleNoFormatting = searchResult.xpath('.//h3')[0].text_content().strip()
         curID = PAutils.Encode(searchResult.xpath('.//a/@href')[0])
-        releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+        releaseDate = searchData.dateFormat() if searchData.date else ''
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 

--- a/Contents/Code/siteVirtualReal.py
+++ b/Contents/Code/siteVirtualReal.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].lower().replace(' ', '-')
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.lower().replace(' ', '-')
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchPage = HTML.ElementFromString(req.text)
 
     titleNoFormatting = searchPage.xpath('//h1')[0].text_content().replace('VR Porn video', '').strip()
@@ -18,10 +18,10 @@ def search(results, lang, siteNum, search):
     script_date = script_text[alpha + 16:omega]
     releaseDate = parse(script_date).strftime('%Y-%m-%d')
 
-    if search['date']:
-        score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+    if searchData.date:
+        score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
     else:
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
     results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s - %s [%s] %s' % (firstActor, titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
     return results

--- a/Contents/Code/siteVirtualTaboo.py
+++ b/Contents/Code/siteVirtualTaboo.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="video-item"]'):
         titleNoFormatting = searchResult.xpath('.//div[@class="video-title"]//a')[0].text_content()
@@ -16,10 +16,10 @@ def search(results, lang, siteNum, search):
             actorList.append(actor.text_content())
         actors = ', '.join(actorList)
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s in %s [%s, %s]' % (actors, titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteVivid.py
+++ b/Contents/Code/siteVivid.py
@@ -2,9 +2,9 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     for sceneType in ['videos', 'dvds']:
-        url = PAsearchSites.getSearchSearchURL(siteNum) + sceneType + '/api/?flagType=video&search=' + search['encoded']
+        url = PAsearchSites.getSearchSearchURL(siteNum) + sceneType + '/api/?flagType=video&search=' + searchData.encoded
         req = PAutils.HTTPRequest(url)
         searchResults = req.json()
         for searchResult in searchResults['responseData']:
@@ -17,10 +17,10 @@ def search(results, lang, siteNum, search):
             releaseDate = parse(searchResult['release_date']).strftime('%Y-%m-%d')
             videoBG = PAutils.Encode(searchResult['placard_800'])
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d|%s|%s' % (curID, siteNum, subSite, videoBG), name='%s [Vivid/%s] %s' % (titleNoFormatting, subSite, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteVogoV.py
+++ b/Contents/Code/siteVogoV.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="video-post-content"]'):
         titleNoFormatting = searchResult.xpath('.//a[@class="video-post-main"]//img/@alt')[0]
@@ -11,10 +11,10 @@ def search(results, lang, siteNum, search):
         curID = PAutils.Encode(searchResult.xpath('.//a[@class="video-post-main"]/@href')[0])
         releaseDate = parse(searchResult.xpath('.//span[@class="video-data float-right"]//em')[0].text_content().strip()).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] [%s] %s' % (titleNoFormatting, femaleActor, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteWUNF.py
+++ b/Contents/Code/siteWUNF.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//a[@class="scene item light_background"]'):
         titleNoFormatting = searchResult.xpath('.//h3')[0].text_content().strip()
@@ -11,7 +11,7 @@ def search(results, lang, siteNum, search):
         sceneURL = searchResult.xpath('./@href')[0]
         curID = PAutils.Encode(sceneURL)
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] [%s]' % (titleNoFormatting, sceneActors, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 
     return results

--- a/Contents/Code/siteWatch4Beauty.py
+++ b/Contents/Code/siteWatch4Beauty.py
@@ -2,17 +2,17 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     modelStrings = []
 
     # start by attempting to fetch the list of scenes for a model
-    if search['title'].lower().find('veronica da souza') >= 0:
+    if searchData.title.lower().find('veronica da souza') >= 0:
         # this is the only 3-word model nickname
         modelString = 'veronica-da-souza'
         modelStrings.append(modelString)
     else:
-        # try the first word or two of the search['title'] as the model name
-        splitWords = search['title'].lower().split()
+        # try the first word or two of the searchData.title as the model name
+        splitWords = searchData.title.lower().split()
         searchWords = []
         for i, searchWord in enumerate(splitWords):
             if i >= 2:
@@ -28,10 +28,10 @@ def search(results, lang, siteNum, search):
             break
 
     if not scenesJson:
-        # no model matches, so try to get the scene info with the search['title']
+        # no model matches, so try to get the scene info with the searchData.title
         Log('No model matches, attempting to match scene title')
 
-        modelsReq = PAutils.HTTPRequest('%s/%s/models' % (w4bApiUrl('scene'), search['title'].replace(' ', '-').lower()))
+        modelsReq = PAutils.HTTPRequest('%s/%s/models' % (w4bApiUrl('scene'), searchData.title.replace(' ', '-').lower()))
         modelsJson = modelsReq.json()
         if modelsJson:
             modelsJson = json.loads(modelsReq.text)
@@ -52,11 +52,11 @@ def search(results, lang, siteNum, search):
         modelName = modelString.replace('-', ' ').title()
         # Log('%s in %s, %s' % (modelString, sceneString, sceneDateString))
 
-        if search['date']:
-            if sceneDateString == search['date']:
+        if searchData.date:
+            if sceneDateString == searchData.date:
                 results.Append(MetadataSearchResult(id='%s|%d|%s' % (modelString, siteNum, sceneString), name='%s, %s [Watch4Beauty]' % (sceneName, sceneDateString), score=100, lang=lang))
-        elif search['title']:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), sceneName.lower())
+        elif searchData.title:
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), sceneName.lower())
             results.Append(MetadataSearchResult(id='%s|%d|%s' % (modelString, siteNum, sceneString), name='%s, %s [Watch4Beauty]' % (sceneName, sceneDateString), score=score, lang=lang))
 
     return results

--- a/Contents/Code/siteWeAreHairy.py
+++ b/Contents/Code/siteWeAreHairy.py
@@ -2,18 +2,18 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="results"]/ul/li'):
         titleNoFormatting = searchResult.xpath('.//p[@class="title"]/a')[0].text_content().strip()
         curID = PAutils.Encode(searchResult.xpath('.//div[@class="top"]/p/a/@href')[0])
         releaseDate = parse(searchResult.xpath('.//p[@class="short"]')[0].text_content().replace('Added:', '').strip()).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [We Are Hairy] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteWicked.py
+++ b/Contents/Code/siteWicked.py
@@ -2,23 +2,23 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    search['encoded'] = search['title'].replace(' ', '-')
-    if '/' not in search['encoded']:
-        search['encoded'].replace('-', '/', 1)
+def search(results, lang, siteNum, searchData):
+    searchData.encoded = searchData.title.replace(' ', '-')
+    if '/' not in searchData.encoded:
+        searchData.encoded.replace('-', '/', 1)
 
-    if 'scene' not in search['encoded'].lower():
-        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+    if 'scene' not in searchData.encoded.lower():
+        req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
         searchResults = HTML.ElementFromString(req.text)
         for searchResult in searchResults.xpath('//div[@class="sceneContainer"]'):
             titleNoFormatting = searchResult.xpath('.//h3')[0].text_content().strip().title().replace('Xxx', 'XXX')
             curID = PAutils.Encode(searchResult.xpath('.//a/@href')[0])
             releaseDate = parse(searchResult.xpath('.//p[@class="sceneDate"]')[0].text_content().strip()).strftime('%Y-%m-%d')
 
-            if search['date']:
-                score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+            if searchData.date:
+                score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
             else:
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
             results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [Wicked/Scene] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 
@@ -26,24 +26,24 @@ def search(results, lang, siteNum, search):
         curID = PAutils.Encode(searchResults.xpath('//link[@rel="canonical"]/@href')[0])
         releaseDate = parse(searchResults.xpath('//li[@class="updatedOn"]')[0].text_content().replace('Updated', '').strip()).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), dvdTitle.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), dvdTitle.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [Wicked/Full Movie] %s' % (dvdTitle, releaseDate), score=score, lang=lang))
 
     else:
-        req = PAutils.HTTPRequest(PAsearchSites.getSearchBaseURL(siteNum) + '/en/video/' + search['encoded'])
+        req = PAutils.HTTPRequest(PAsearchSites.getSearchBaseURL(siteNum) + '/en/video/' + searchData.encoded)
         searchResults = HTML.ElementFromString(req.text)
         titleNoFormatting = searchResults.xpath('//h1//span')[0].text_content().strip().title().replace('Xxx', 'XXX')
         curID = PAutils.Encode(searchResults.xpath('//link[@rel="canonical"]/@href')[0])
         releaseDate = parse(searchResults.xpath('//li[@class="updatedDate"]')[0].text_content().replace('Updated', '').replace('|', '').strip()).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [Wicked/Scene] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteWoodmanCastingX.py
+++ b/Contents/Code/siteWoodmanCastingX.py
@@ -2,15 +2,15 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[@class="items container_4"]/a[@class="item scene"]'):
         titleNoFormatting = searchResult.xpath('./img/@alt')[0]
         sceneURL = searchResult.xpath('./@href')[0]
         curID = PAutils.Encode(sceneURL)
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 
     return results

--- a/Contents/Code/siteWowGirls.py
+++ b/Contents/Code/siteWowGirls.py
@@ -3,27 +3,27 @@ import PAextras
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//article//a'):
         siteName = PAsearchSites.getSearchSiteName(siteNum) + '.xxx'
         titleNoFormatting = searchResult.xpath('./@title')[0]
         curID = PAutils.Encode(searchResult.xpath('./@href')[0])
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s]' % (titleNoFormatting, siteName), score=score, lang=lang))
 
     url = PAsearchSites.getSearchSearchURL(siteNum).replace('.xxx', '.tv', 1)
-    req = PAutils.HTTPRequest(url + search['encoded'])
+    req = PAutils.HTTPRequest(url + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[contains(@class, "entry")]//h3//a'):
         siteName = PAsearchSites.getSearchSiteName(siteNum) + '.tv'
         titleNoFormatting = searchResult.xpath('./text()')[0].strip()
         curID = PAutils.Encode(searchResult.xpath('./@href')[0])
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s]' % (titleNoFormatting, siteName), score=score, lang=lang))
 

--- a/Contents/Code/siteXConfessions.py
+++ b/Contents/Code/siteXConfessions.py
@@ -30,16 +30,16 @@ def getDatafromAPI(baseURL, searchData, token, search=True):
     return data
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     token = getToken(PAsearchSites.getSearchBaseURL(siteNum))
     if token:
-        searchResults = getDatafromAPI(PAsearchSites.getSearchSearchURL(siteNum), search['title'], token)
+        searchResults = getDatafromAPI(PAsearchSites.getSearchSearchURL(siteNum), searchData.title, token)
         for searchResult in searchResults:
             if searchResult['resourceType'] == 'movies':
                 curID = searchResult['slug']
                 titleNoFormatting = searchResult['title']
 
-                score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
                 results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s' % (titleNoFormatting), score=score, lang=lang))
 

--- a/Contents/Code/siteXVirtual.py
+++ b/Contents/Code/siteXVirtual.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[contains(@class, "episode-list")]/div[contains(@class, "episode")]'):
         titleNoFormatting = searchResult.xpath('.//h2')[0].text_content().strip()
@@ -13,9 +13,9 @@ def search(results, lang, siteNum, search):
             sceneURL = PAsearchSites.getSearchBaseURL(siteNum) + sceneURL
         curID = PAutils.Encode(sceneURL)
 
-        releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+        releaseDate = searchData.dateFormat() if searchData.date else ''
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s]' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum)), score=score, lang=lang))
 

--- a/Contents/Code/siteXart.py
+++ b/Contents/Code/siteXart.py
@@ -3,9 +3,9 @@ import PAextras
 import PAutils
 
 
-def search(results, lang, siteNum, search):
+def search(results, lang, siteNum, searchData):
     params = {
-        'input_search_sm': search['encoded']
+        'input_search_sm': searchData.encoded
     }
     req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum), params=params)
     searchResults = HTML.ElementFromString(req.text)
@@ -18,15 +18,15 @@ def search(results, lang, siteNum, search):
                 releaseDate = parse(searchResult.xpath('.//h2[2]')[0].text_content().strip()).strftime('%Y-%m-%d')
                 curID = PAutils.Encode(searchResult.get('href'))
 
-                if search['date']:
-                    score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+                if searchData.date:
+                    score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
                 else:
-                    score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+                    score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
                 results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 
-    if search['title'] in manualMatch:
-        item = manualMatch[search['title']]
+    if searchData.title in manualMatch:
+        item = manualMatch[searchData.title]
         curID = PAutils.Encode(item['curID'])
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name=item['name'], score=101, lang=lang))

--- a/Contents/Code/siteXillimite.py
+++ b/Contents/Code/siteXillimite.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//a[contains(@class, "movies")]'):
         titleNoFormatting = searchResult.xpath('.//img/@alt')[0].strip()
@@ -13,9 +13,9 @@ def search(results, lang, siteNum, search):
             sceneURL = PAsearchSites.getSearchBaseURL(siteNum) + sceneURL
 
         curID = PAutils.Encode(sceneURL)
-        releaseDate = parse(search['date']).strftime('%Y-%m-%d') if search['date'] else ''
+        releaseDate = searchData.dateFormat() if searchData.date else ''
 
-        score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+        score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
 

--- a/Contents/Code/siteZTOD.py
+++ b/Contents/Code/siteZTOD.py
@@ -2,8 +2,8 @@ import PAsearchSites
 import PAutils
 
 
-def search(results, lang, siteNum, search):
-    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + search['encoded'])
+def search(results, lang, siteNum, searchData):
+    req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded)
     searchResults = HTML.ElementFromString(req.text)
     for searchResult in searchResults.xpath('//div[contains(@class, "video-container")]'):
         titleNoFormatting = searchResult.xpath('.//a[@class="video-title"]')[0].text_content().strip()
@@ -11,10 +11,10 @@ def search(results, lang, siteNum, search):
         curID = PAutils.Encode(sceneURL)
         releaseDate = parse(searchResult.xpath('.//ul[contains(@class,"desclist")]/li[1]')[0].text_content().strip()).strftime('%Y-%m-%d')
 
-        if search['date']:
-            score = 100 - Util.LevenshteinDistance(search['date'], releaseDate)
+        if searchData.date:
+            score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
-            score = 100 - Util.LevenshteinDistance(search['title'].lower(), titleNoFormatting.lower())
+            score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
         results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s [ZTOD] %s' % (titleNoFormatting, releaseDate), score=score, lang=lang))
 


### PR DESCRIPTION
The main change here is that the former `search` dictionary is deprecated in favour of a `searchData` object, which is an instance of class `SearchData`.

The `SearchData` class lists its properties, and also allows extension with useful methods, such as dateFormat() and durationFormat(), which are already implemented.

All providers are updated to make use of the new object, and instances of `parse(someDateVariable).strftime('%Y-%m-%d')` are updated to make use of the `dateFormat()` method.

A new version of `siteAtkGirlfriends.py` is incoming that makes use of the `durationFormat()` method to allow hugely improved matching.

Secondly, some of the variable names within PhoenixAdult.search() are updated to make them a little more descriptive, especially in the section that deals with generating search strings from the parent directory of the media being matched.

Logging within the search function is tidied up to make it slightly more descriptive and to remove redundancy.