### PR TITLE
Fix nympho scene URL matching

### DIFF
--- a/Contents/Code/networkSteppedUp.py
+++ b/Contents/Code/networkSteppedUp.py
@@ -1,10 +1,11 @@
 import PAsearchSites
 import PAutils
+import re
 
 
 def search(results, lang, siteNum, searchData):
     searchData.encoded = searchData.title.replace(' ', '-').replace('--', '-').replace('\'', '').lower()
-    if '/' not in searchData.encoded:
+    if "/" not in encodedTitle and re.match("\d+.*",encodedTitle):
         searchData.encoded = searchData.encoded.replace('-', '/', 1)
 
     sceneURL = PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded


### PR DESCRIPTION
Nympho changed their scene URL pattern. 
Old pattern was `view/id/title-of-scene`.
New pattern is `view/title-of-scene`.
However, matching old scenes by old pattern still works, so these changes enable both patterns to work.