### PR TITLE
indexxx.com actorDBfinder and deploy actorSave/cacheActorPhoto

### DIFF
--- a/Contents/Code/PAactors.py
+++ b/Contents/Code/PAactors.py
@@ -115,8 +115,8 @@ def actorDBfinder(actorName):
             actorPage = HTML.ElementFromString(req.text)
             img = actorPage.xpath('//img[@class="model-img"]/@src')
             if img:
-                actorPhotoURL = cacheActorPhoto(img[0], actorName, headers={'Referer': actorPageURL})
-                Log("Local image: %s" % actorPhotoURL)
+                actorPhotoURL = img[0]
+                actorPhotoURL = cacheActorPhoto(actorPhotoURL, actorName, headers={'Referer': actorPageURL})
 
     if not actorPhotoURL:
         databaseName = 'AdultDVDEmpire'
@@ -176,6 +176,7 @@ def actorDBfinder(actorName):
             Log('%s not found' % actorName)
 
     return actorPhotoURL
+
 
 # fetches a copy of an actor image and stores it locally, then returns a URL from which Plex can fetch it later
 def cacheActorPhoto(url, actorName, **kwargs):


### PR DESCRIPTION
…kes sense to query indexxx.com first for model photos. Makes use of the new actor photo fetch/save/serve facility, which is renamed `cacheActorPhoto` to be more descriptive