### PR TITLE
Fix multi-source actor matching

### DIFF
--- a/Contents/Code/PAactors.py
+++ b/Contents/Code/PAactors.py
@@ -119,7 +119,7 @@ def actorDBfinder(actorName):
 
     searchOrder = ['Local Storage', 'Freeones', 'IAFD', 'Indexxx', 'AdultDVDEmpire', 'Boobpedia', 'Babes and Stars', 'Babepedia']
     if Prefs['order_enable']:
-        searchOrder = [sourceName.strip() for sourceName in Prefs['order_list'].split(',') if sourceName in searchResults]
+        searchOrder = [sourceName.strip() for sourceName in Prefs['order_list'].split(',') if sourceName.strip() in searchResults]
 
     for sourceName in searchOrder:
         task = searchResults[sourceName]


### PR DESCRIPTION
This was a sneaky bug, as it would only appear in the event that the first actor DB site checked did **not** find a match, at which point it would return no result.

Example:
Custom order: YES
Order: `IAFD, Local Storage, Indexxx, Freeones, AdultDVDEmpire, Boobpedia, Babes and Stars, Babepedia`
Search for actor `Melena Maria Rya`
-- IAFD has no record for this actor, so we would expect to move on to local storage then Indexxx etc...

But we don't, because custom order would return only the first item because it in the example list, it was comparing `IAFD` with `IAFD ` (trailing space), resulting in no matching sourceName