### PR TITLE
Fix IAFD matching and new actor facility for Jacqui Et Michel TV

### DIFF
--- a/Contents/Code/PAactors.py
+++ b/Contents/Code/PAactors.py
@@ -216,7 +216,7 @@ def getFromIAFD(actorName, actorEncoded):
 
     req = PAutils.HTTPRequest('http://www.iafd.com/results.asp?searchtype=comprehensive&searchstring=' + actorEncoded)
     actorSearch = HTML.ElementFromString(req.text)
-    actorPageURL = actorSearch.xpath('//table[@id="tblFem"]//tbody//a/@href')
+    actorPageURL = actorSearch.xpath('//table[@id="tblFem" or @id="tblMal"]//tbody//a/@href')
     if actorPageURL:
         actorPageURL = 'http://www.iafd.com' + actorPageURL[0]
         req = PAutils.HTTPRequest(actorPageURL)

--- a/Contents/Code/siteJacquieEtMichel.py
+++ b/Contents/Code/siteJacquieEtMichel.py
@@ -80,6 +80,11 @@ def update(metadata, siteNum, movieGenres, movieActors):
     metadata.originally_available_at = date_object
     metadata.year = metadata.originally_available_at.year
 
+    # Actors
+    movieActors.clearActors()
+    for actor in getJMTVActors(sceneURL):
+       movieActors.addActor(actor, '')
+
     # Poster
     art = []
 
@@ -114,3 +119,40 @@ def update(metadata, siteNum, movieGenres, movieActors):
                 pass
 
     return metadata
+
+def getJMTVActors(url):
+    # actors for scenes must be manually specified using a URL fragment:
+    scenes = {
+        '4554/ibiza-1-crumb-in-the-mouth': [
+            'Alexis Crystal',
+            'Cassie Del Isla',
+            'Dorian Del Isla'],
+        '4558/orgies-in-ibiza-2-lucys-surprise': [
+            'Alexis Crystal',
+            'Cassie Del Isla',
+            'Lucy Heart',
+            'Dorian Del Isla',
+            'James Burnett Klein',
+            'Vlad Castle'],
+        '4564/orgies-in-ibiza-3-overheated-orgy-by-the-pool': [
+            'Alexis Crystal',
+            'Cassie Del Isla',
+            'Lucy Heart',
+            'Dorian Del Isla',
+            'James Burnett Klein',
+            'Vlad Castle'],
+        '4570/orgies-in-ibiza-4-orgy-with-a-bang-for-the-last-night': [
+            'Alexis Crystal',
+            'Cassie Del Isla',
+            'Lucy Heart',
+            'Dorian Del Isla',
+            'James Burnett Klein',
+            'Vlad Castle'],
+    }
+
+    for urlFragment, actors in scenes.items():
+        if urlFragment in url:
+            Log('Actors manually specified %s' % actors)
+            return actors
+
+    return []

--- a/Contents/Code/siteJacquieEtMichel.py
+++ b/Contents/Code/siteJacquieEtMichel.py
@@ -82,14 +82,16 @@ def update(metadata, siteNum, movieGenres, movieActors):
 
     # Actors
     movieActors.clearActors()
-    for actor in getJMTVActors(sceneURL):
-       movieActors.addActor(actor, '')
+    for actorLink in getJMTVActors(sceneURL):
+        actorName = actorLink
+        actorPhotoURL = ''
+
+        movieActors.addActor(actorName, actorPhotoURL)
 
     # Poster
     art = []
-
     xpaths = [
-        '//img[@id="video-player-poster"]/@data-src'
+        '//img[@id="video-player-poster"]/@data-src',
     ]
 
     for xpath in xpaths:
@@ -120,39 +122,45 @@ def update(metadata, siteNum, movieGenres, movieActors):
 
     return metadata
 
+
 def getJMTVActors(url):
     # actors for scenes must be manually specified using a URL fragment:
     scenes = {
         '4554/ibiza-1-crumb-in-the-mouth': [
             'Alexis Crystal',
             'Cassie Del Isla',
-            'Dorian Del Isla'],
+            'Dorian Del Isla',
+        ],
         '4558/orgies-in-ibiza-2-lucys-surprise': [
             'Alexis Crystal',
             'Cassie Del Isla',
             'Lucy Heart',
             'Dorian Del Isla',
             'James Burnett Klein',
-            'Vlad Castle'],
+            'Vlad Castle',
+        ],
         '4564/orgies-in-ibiza-3-overheated-orgy-by-the-pool': [
             'Alexis Crystal',
             'Cassie Del Isla',
             'Lucy Heart',
             'Dorian Del Isla',
             'James Burnett Klein',
-            'Vlad Castle'],
+            'Vlad Castle',
+        ],
         '4570/orgies-in-ibiza-4-orgy-with-a-bang-for-the-last-night': [
             'Alexis Crystal',
             'Cassie Del Isla',
             'Lucy Heart',
             'Dorian Del Isla',
             'James Burnett Klein',
-            'Vlad Castle'],
+            'Vlad Castle',
+        ],
     }
 
+    actorList = []
     for urlFragment, actors in scenes.items():
         if urlFragment in url:
-            Log('Actors manually specified %s' % actors)
-            return actors
+            actorList = actors
+            break
 
-    return []
+    return actorList


### PR DESCRIPTION
IAFD matching would break if the actor was male, as it was only scanning #tblFem, while male results would sit in #tblMal - the xpath now includes both. Also added a facility to manually specify actors for Jacqie Et Michel TV with some examples.