### PR TITLE
Display studio when showing search results

### DIFF
--- a/Contents/Code/siteData18Movies.py
+++ b/Contents/Code/siteData18Movies.py
@@ -35,6 +35,21 @@ def search(results, lang, siteNum, searchData):
 
             date = searchResult.text
 
+            sceneURL = PAutils.Decode(curID)
+            req = PAutils.HTTPRequest(sceneURL)
+            detailsPageElements = HTML.ElementFromString(req.text)
+
+            # Studio
+            try:
+                studio = detailsPageElements.xpath('//i[contains(., "Network")]//preceding-sibling::a[1]')[0].text_content().strip()
+            except:
+                try:
+                    studio = detailsPageElements.xpath('//i[contains(., "Studio")]//preceding-sibling::a[1]')[0].text_content().strip()
+                except:
+                    try:
+                        studio = detailsPageElements.xpath('//i[contains(., "Site")]//preceding-sibling::a[1]')[0].text_content().strip()
+                    except:
+                        studio = ''
             if date and not date == 'unknown':
                 try:
                     releaseDate = datetime.strptime(date, '%Y%m%d').strftime('%Y-%m-%d')
@@ -53,9 +68,9 @@ def search(results, lang, siteNum, searchData):
 
             if score == 80:
                 count += 1
-                temp.append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s %s' % (titleNoFormatting, displayDate), score=score, lang=lang))
+                temp.append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, studio, displayDate), score=score, lang=lang))
             else:
-                results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s %s' % (titleNoFormatting, displayDate), score=score, lang=lang))
+                results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, studio, displayDate), score=score, lang=lang))
 
     googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for movieURL in googleResults:

--- a/Contents/Code/siteData18Movies.py
+++ b/Contents/Code/siteData18Movies.py
@@ -35,21 +35,6 @@ def search(results, lang, siteNum, searchData):
 
             date = searchResult.text
 
-            sceneURL = PAutils.Decode(curID)
-            req = PAutils.HTTPRequest(sceneURL)
-            detailsPageElements = HTML.ElementFromString(req.text)
-
-            # Studio
-            try:
-                studio = detailsPageElements.xpath('//i[contains(., "Network")]//preceding-sibling::a[1]')[0].text_content().strip()
-            except:
-                try:
-                    studio = detailsPageElements.xpath('//i[contains(., "Studio")]//preceding-sibling::a[1]')[0].text_content().strip()
-                except:
-                    try:
-                        studio = detailsPageElements.xpath('//i[contains(., "Site")]//preceding-sibling::a[1]')[0].text_content().strip()
-                    except:
-                        studio = ''
             if date and not date == 'unknown':
                 try:
                     releaseDate = datetime.strptime(date, '%Y%m%d').strftime('%Y-%m-%d')
@@ -66,11 +51,34 @@ def search(results, lang, siteNum, searchData):
             else:
                 score = 80 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
-            if score == 80:
-                count += 1
-                temp.append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, studio, displayDate), score=score, lang=lang))
+            
+            if (score > 70):
+                sceneURL = PAutils.Decode(curID)
+                req = PAutils.HTTPRequest(sceneURL)
+                detailsPageElements = HTML.ElementFromString(req.text)
+
+                # Studio
+                try:
+                    studio = detailsPageElements.xpath('//i[contains(., "Network")]//preceding-sibling::a[1]')[0].text_content().strip()
+                except:
+                    try:
+                        studio = detailsPageElements.xpath('//i[contains(., "Studio")]//preceding-sibling::a[1]')[0].text_content().strip()
+                    except:
+                        try:
+                            studio = detailsPageElements.xpath('//i[contains(., "Site")]//preceding-sibling::a[1]')[0].text_content().strip()
+                        except:
+                            studio = ''
+                if score == 80:
+                    count += 1
+                    temp.append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, studio, displayDate), score=score, lang=lang))
+                else:
+                    results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, studio, displayDate), score=score, lang=lang))
             else:
-                results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, studio, displayDate), score=score, lang=lang))
+                if score == 80:
+                    count += 1
+                    temp.append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s %s' % (titleNoFormatting, displayDate), score=score, lang=lang))
+                else:
+                    results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s %s' % (titleNoFormatting, displayDate), score=score, lang=lang))
 
     googleResults = PAutils.getFromGoogleSearch(searchData.title, siteNum)
     for movieURL in googleResults:

--- a/Contents/Code/siteData18Movies.py
+++ b/Contents/Code/siteData18Movies.py
@@ -51,8 +51,7 @@ def search(results, lang, siteNum, searchData):
             else:
                 score = 80 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
-            
-            if (score > 70):
+            if score > 70:
                 sceneURL = PAutils.Decode(curID)
                 req = PAutils.HTTPRequest(sceneURL)
                 detailsPageElements = HTML.ElementFromString(req.text)
@@ -68,6 +67,7 @@ def search(results, lang, siteNum, searchData):
                             studio = detailsPageElements.xpath('//i[contains(., "Site")]//preceding-sibling::a[1]')[0].text_content().strip()
                         except:
                             studio = ''
+
                 if score == 80:
                     count += 1
                     temp.append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, studio, displayDate), score=score, lang=lang))


### PR DESCRIPTION
Currently searching with Data18 can be a mess - tons of similar results and no way to really tell which is the one you want.

Changes will show Studio in brackets in search result to make matching a bit easier.

![image](https://user-images.githubusercontent.com/81722832/113412594-afd7fa80-9386-11eb-9df1-b0360cc8ca4b.png)
