### PR TITLE
Support for individual scenes

### DIFF
--- a/Contents/Code/siteData18Content.py
+++ b/Contents/Code/siteData18Content.py
@@ -171,6 +171,10 @@ def update(metadata, lang, siteNum, movieGenres, movieActors):
     metadata.collections.clear()
     try:
         tagline = detailsPageElements.xpath('//i[contains(., "Site")]//preceding-sibling::a[1]')[0].text_content().strip()
+        if len(metadata_id) > 3:
+            Log("Using original series information")
+            tagline = detailsPageElements.xpath('//p[contains(., "Serie")]//a[@title]')[0].text_content().strip()
+            metadata.title = ("%s [Scene %s]" % (metadata_id[3], metadata_id[4]))
         if not metadata.studio:
             metadata.studio = tagline
         else:

--- a/Contents/Code/siteData18Content.py
+++ b/Contents/Code/siteData18Content.py
@@ -1,5 +1,4 @@
 import PAsearchSites
-import PAextras
 import PAutils
 
 
@@ -172,7 +171,7 @@ def update(metadata, lang, siteNum, movieGenres, movieActors):
     try:
         tagline = detailsPageElements.xpath('//i[contains(., "Site")]//preceding-sibling::a[1]')[0].text_content().strip()
         if len(metadata_id) > 3:
-            Log("Using original series information")
+            Log('Using original series information')
             tagline = detailsPageElements.xpath('//p[contains(., "Serie")]//a[@title]')[0].text_content().strip()
             metadata.title = ("%s [Scene %s]" % (metadata_id[3], metadata_id[4]))
         if not metadata.studio:

--- a/Contents/Code/siteData18Movies.py
+++ b/Contents/Code/siteData18Movies.py
@@ -1,5 +1,4 @@
 import PAsearchSites
-import PAextras
 import PAutils
 import siteData18Content
 
@@ -187,7 +186,7 @@ def update(metadata, lang, siteNum, movieGenres, movieActors):
     detailsPageElements = HTML.ElementFromString(req.text)
 
     if len(metadata_id) > 3:
-        Log("Switching to Data18Content")
+        Log('Switching to Data18Content')
         siteData18Content.update(metadata, lang, siteNum, movieGenres, movieActors)
         return metadata
     

--- a/Contents/Code/siteData18Movies.py
+++ b/Contents/Code/siteData18Movies.py
@@ -137,11 +137,38 @@ def search(results, lang, siteNum, searchData):
         else:
             score = 80 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
+        # Studio
+        try:
+            studio = detailsPageElements.xpath('//i[contains(., "Network")]//preceding-sibling::a[1]')[0].text_content().strip()
+        except:
+            try:
+                studio = detailsPageElements.xpath('//i[contains(., "Studio")]//preceding-sibling::a[1]')[0].text_content().strip()
+            except:
+                try:
+                    studio = detailsPageElements.xpath('//i[contains(., "Site")]//preceding-sibling::a[1]')[0].text_content().strip()
+                except:
+                    studio = ''
+
         if score == 80:
             count += 1
-            temp.append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, siteName, displayDate), score=score, lang=lang))
+            temp.append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, studio, displayDate), score=score, lang=lang))
         else:
-            results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, siteName, displayDate), score=score, lang=lang))
+            results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, studio, displayDate), score=score, lang=lang))
+        
+        #Split Scenes
+        sceneCount = detailsPageElements.xpath('//text()[contains(., "Related Scenes")]')[0][-2]
+        if sceneCount.isdigit():
+            sceneCount = int(sceneCount)
+        else:
+            sceneCount = 0
+        for sceneNum in range(1,sceneCount + 1):
+            section = "Scene " + str(sceneNum)
+            scene = PAutils.Encode(detailsPageElements.xpath('//a[contains(., "%s")]/@href' % (section))[0])
+            if score == 80:
+                count += 1
+                temp.append(MetadataSearchResult(id='%s|%d|%s|%s|%d' % (scene, siteNum, releaseDate, titleNoFormatting, sceneNum), name='%s [%s][%s] %s' % (titleNoFormatting, section, studio, displayDate), score=score, lang=lang))
+            else:
+                results.Append(MetadataSearchResult(id='%s|%d|%s|%s|%d' % (scene, siteNum, releaseDate, titleNoFormatting, sceneNum), name='%s [%s][%s] %s' % (titleNoFormatting, section, studio, displayDate), score=score, lang=lang))
 
     for result in temp:
         if count > 1 and result.score == 80:

--- a/Contents/Code/siteData18Movies.py
+++ b/Contents/Code/siteData18Movies.py
@@ -1,7 +1,7 @@
 import PAsearchSites
 import PAextras
 import PAutils
-
+import siteData18Content
 
 def search(results, lang, siteNum, searchData):
     searchResults = []
@@ -73,6 +73,21 @@ def search(results, lang, siteNum, searchData):
                     temp.append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, studio, displayDate), score=score, lang=lang))
                 else:
                     results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, studio, displayDate), score=score, lang=lang))
+                
+                #Split Scenes
+                sceneCount = detailsPageElements.xpath('//text()[contains(., "Related Scenes")]')[0][-2]
+                if sceneCount.isdigit():
+                    sceneCount = int(sceneCount)
+                else:
+                    sceneCount = 0
+                for sceneNum in range(1,sceneCount + 1):
+                    section = "Scene " + str(sceneNum)
+                    scene = PAutils.Encode(detailsPageElements.xpath('//a[contains(., "%s")]/@href' % (section))[0])
+                    if score == 80:
+                        count += 1
+                        temp.append(MetadataSearchResult(id='%s|%d|%s|%s|%d' % (scene, siteNum, releaseDate, titleNoFormatting, sceneNum), name='%s [%s][%s] %s' % (titleNoFormatting, section, studio, displayDate), score=score, lang=lang))
+                    else:
+                        results.Append(MetadataSearchResult(id='%s|%d|%s|%s|%d' % (scene, siteNum, releaseDate, titleNoFormatting, sceneNum), name='%s [%s][%s] %s' % (titleNoFormatting, section, studio, displayDate), score=score, lang=lang))
             else:
                 if score == 80:
                     count += 1
@@ -144,6 +159,11 @@ def update(metadata, lang, siteNum, movieGenres, movieActors):
     req = PAutils.HTTPRequest(sceneURL)
     detailsPageElements = HTML.ElementFromString(req.text)
 
+    if len(metadata_id) > 3:
+        Log("Switching to Data18Content")
+        siteData18Content.update(metadata, lang, siteNum, movieGenres, movieActors)
+        return metadata
+    
     # Title
     metadata.title = PAutils.parseTitle(detailsPageElements.xpath('//h1')[0].text_content(), siteNum)
 


### PR DESCRIPTION
Data18 Movies have a breakdown of individual scenes in the movie. Many torrents come with these movies split into their original scenes.

Example: [Horny Housewives #1](http://www.data18.com/movies/1130883)

Check to see if there are any related scenes, and if so how many (Look at `Related Scenes [6]`)
Get each individual scene's link and add them to the search results in the format 
`Title [Scene X][studio] Date`

If the specific scene is chosen, the link (curID) for the entire movie will be replaced by the individual scene link in the `id` field

The ID field will have two new pieces of information added: original title (Horny Housewives #1)  and scene number (1).

In the `data18Movie`s update function, if the id field has more than 3 sections, the code will then switch to use the `data18Contents` update function as the individual scene is under the data18 Content section (e.x: http://www.data18.com/content/1114634)

Within the `data18Contents` update function, if the scene is a split scene (check if id has more than 3 fields) then 
the `tagline` will become the series (Horny Housewives) not the site (Real Wife Stories) 
the `title` will be in the format - `Movie [Scene x]` or `Horny Housewives #1 [Scene 1]`