### PR TITLE
Use AdultEmpire site for DVD split scenes

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -61,7 +61,7 @@ class PhoenixAdultAgent(Agent.Movies):
         title = getSearchTitle(title)
 
         #Use AdultEmpire to check dvd split scenes automatically
-        scene_title = re.search(r'.*(?=.Scene\s\d)', title).group()
+        scene_title = re.search(r'.*(?=.Scene\s\d)', title)
         if scene_title is not None:
             searchSettings = {
                 'siteNum': 1334,

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -60,16 +60,28 @@ class PhoenixAdultAgent(Agent.Movies):
 
         title = getSearchTitle(title)
 
+        #Use AdultEmpire to check dvd split scenes automatically
+        scene_title = re.search(r'.*(?=.Scene\s\d)', title).group()
+        if scene_title is not None:
+            searchSettings = {
+                'siteNum': 1334,
+                'siteName': "Adult Empire",
+                'searchTitle': title,
+                'searchDate': None,
+            }
+
+
         Log('***MEDIA TITLE [from media.name]*** %s' % title)
-        searchSettings = PAsearchSites.getSearchSettings(title)
-        Log(searchSettings)
+        if searchSettings is None:
+            searchSettings = PAsearchSites.getSearchSettings(title)
+            Log(searchSettings)
 
         filepath = None
         filename = None
         if media.filename:
             filepath = urllib.unquote(media.filename)
             filename = str(os.path.splitext(os.path.basename(filepath))[0])
-
+        
         if searchSettings['siteNum'] is None and filepath:
             directory = str(os.path.split(os.path.dirname(filepath))[1])
 

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -60,21 +60,9 @@ class PhoenixAdultAgent(Agent.Movies):
 
         title = getSearchTitle(title)
 
-        #Use AdultEmpire to check dvd split scenes automatically
-        scene_title = re.search(r'.*(?=.Scene\s\d)', title)
-        if scene_title is not None:
-            searchSettings = {
-                'siteNum': 1334,
-                'siteName': "Adult Empire",
-                'searchTitle': title,
-                'searchDate': None,
-            }
-
-
         Log('***MEDIA TITLE [from media.name]*** %s' % title)
-        if searchSettings is None:
-            searchSettings = PAsearchSites.getSearchSettings(title)
-            Log(searchSettings)
+        searchSettings = PAsearchSites.getSearchSettings(title)
+        Log(searchSettings)
 
         filepath = None
         filename = None
@@ -82,6 +70,17 @@ class PhoenixAdultAgent(Agent.Movies):
             filepath = urllib.unquote(media.filename)
             filename = str(os.path.splitext(os.path.basename(filepath))[0])
         
+        #Use AdultEmpire to check dvd split scenes automatically
+        if searchSettings['siteNum'] is None:
+            scene_title = re.search(r'.*(?=.Scene\s\d)', title)
+            if scene_title is not None:
+                searchSettings = {
+                    'siteNum': 1334,
+                    'siteName': "Adult Empire",
+                    'searchTitle': title,
+                    'searchDate': None,
+                }
+
         if searchSettings['siteNum'] is None and filepath:
             directory = str(os.path.split(os.path.dirname(filepath))[1])
 

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -70,17 +70,6 @@ class PhoenixAdultAgent(Agent.Movies):
             filepath = urllib.unquote(media.filename)
             filename = str(os.path.splitext(os.path.basename(filepath))[0])
         
-        #Use AdultEmpire to check dvd split scenes automatically
-        if searchSettings['siteNum'] is None:
-            scene_title = re.search(r'.*(?=.Scene\s\d)', title)
-            if scene_title is not None:
-                searchSettings = {
-                    'siteNum': 1334,
-                    'siteName': "Adult Empire",
-                    'searchTitle': title,
-                    'searchDate': None,
-                }
-
         if searchSettings['siteNum'] is None and filepath:
             directory = str(os.path.split(os.path.dirname(filepath))[1])
 
@@ -95,6 +84,18 @@ class PhoenixAdultAgent(Agent.Movies):
                 newTitle = '%s %s' % (newTitle, title)
                 Log('***MEDIA TITLE [from directory + media.name]*** %s' % newTitle)
                 searchSettings = PAsearchSites.getSearchSettings(newTitle)
+
+        #Use AdultEmpire to check dvd split scenes automatically
+        if searchSettings['siteNum'] is None:
+            Log("checking for adultempire")
+            scene_title = re.search(r'.*(?=.Scene\s\d)', title)
+            if scene_title is not None:
+                searchSettings = {
+                    'siteNum': 1334,
+                    'siteName': "Adult Empire",
+                    'searchTitle': title,
+                    'searchDate': None,
+                }
 
         providerName = None
         siteNum = searchSettings['siteNum']

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -69,7 +69,7 @@ class PhoenixAdultAgent(Agent.Movies):
         if media.filename:
             filepath = urllib.unquote(media.filename)
             filename = str(os.path.splitext(os.path.basename(filepath))[0])
-        
+
         if searchSettings['siteNum'] is None and filepath:
             directory = str(os.path.split(os.path.dirname(filepath))[1])
 
@@ -85,7 +85,7 @@ class PhoenixAdultAgent(Agent.Movies):
                 Log('***MEDIA TITLE [from directory + media.name]*** %s' % newTitle)
                 searchSettings = PAsearchSites.getSearchSettings(newTitle)
 
-        #Use AdultEmpire to check dvd split scenes automatically
+        # Use AdultEmpire to check dvd split scenes automatically
         if searchSettings['siteNum'] is None:
             Log("checking for adultempire")
             scene_title = re.search(r'.*(?=.Scene\s\d)', title)

--- a/Contents/Code/siteAdultEmpire.py
+++ b/Contents/Code/siteAdultEmpire.py
@@ -68,7 +68,7 @@ def search(results, lang, siteNum, searchData):
                         studio = detailsPageElements.xpath('//ul[@class="list-unstyled m-b-2"]/li[contains(., "Studio:")]/a/text()')[0].strip()
                     except:
                         studio = ''
-                        
+
                     if sceneID == urlID:
                         score = 100
                     elif searchData.date and displayDate:


### PR DESCRIPTION
Use AdultEmpire for split scenes from DVDs.
File's with name "Scene x" in filename will use [siteAdultEmpire](https://github.com/PAhelper/PhoenixAdult.bundle/blob/a0a0e534cafc23573548da1f5ed9cac60fffc67e/Contents/Code/siteAdultEmpire.py)

Once the scene matching the specified title exactly and scene number is found, it will stop searching to speed things up.