### PR TITLE
Fixed Clips4Sale search

### DIFF
--- a/Contents/Code/siteClips4Sale.py
+++ b/Contents/Code/siteClips4Sale.py
@@ -4,7 +4,7 @@ import PAutils
 
 def search(results, lang, siteNum, searchData):
     parts = searchData.title.split(' ', 1)
-    if len(parts) == 1 and searchData.filename != searchData.title:
+    if len(parts) != 1 and searchData.filename != searchData.title:
         parts.append(searchData.filename)
     else:
         Log('No scene name')


### PR DESCRIPTION
The logic of the parts string handling had it logging "no scene name" if you included the Studio ID (userID) and a title. By changing the ==1 to !=1, it now appends the title to the search