### PR TITLE
Fix matching issue between Scoreland and Scoreland 2

### DIFF
--- a/Contents/Code/PAsiteList.py
+++ b/Contents/Code/PAsiteList.py
@@ -1518,7 +1518,7 @@ searchSites = {
     1342: ('TS Casting Couch', 'https://www.ts-castingcouch.com', '/tour/trailers/'),
     1343: ('Black TGirls', 'https://www.black-tgirls.com', '/tour/trailers/'),
     1344: ('Christy Marks', 'https://www.christymarks.com', '/videos/'),
-    1345: ('Scoreland2', 'https://www.scoreland2.com', '/big-boob-scenes/'),
+    1345: ('ScorelandTwo', 'https://www.scoreland2.com', '/big-boob-scenes/'),
     1346: ('DarkRoomVR', 'https://darkroomvr.com', '/search?q='),
     1347: ('Puba', 'https://www.puba.com', '/pornstarnetwork/'),
 }
@@ -1761,6 +1761,7 @@ abbreviations = (
     ('^wy ', 'WebYoung '),
     ('^ztod ', 'ZeroTolerance '),
     ('^zzs ', 'ZZseries '),
+    ('^scoreland2', 'ScorelandTwo ')
 )
 
 

--- a/Contents/Code/PAsiteList.py
+++ b/Contents/Code/PAsiteList.py
@@ -1719,6 +1719,7 @@ abbreviations = (
     ('^sart ', 'SexArt '),
     ('^sas ', 'SexandSubmission '),
     ('^sbj ', 'StreetBlowjobs '),
+    ('^scoreland2', 'ScorelandTwo '),
     ('^seb ', 'SexuallyBroken '),
     ('^sed ', 'SexualDisgrace '),
     ('^Shes New ', 'She\'s New '),
@@ -1761,7 +1762,6 @@ abbreviations = (
     ('^wy ', 'WebYoung '),
     ('^ztod ', 'ZeroTolerance '),
     ('^zzs ', 'ZZseries '),
-    ('^scoreland2', 'ScorelandTwo ')
 )
 
 

--- a/Contents/Code/networkScoreGroup.py
+++ b/Contents/Code/networkScoreGroup.py
@@ -66,6 +66,9 @@ def update(metadata, lang, siteNum, movieGenres, movieActors):
         actorPhotoURL = ''
 
         movieActors.addActor(actorName, actorPhotoURL)
+    
+    if siteNum == 1344:
+        movieActors.addActor('Christy Marks', '')
 
     # Genres
     movieGenres.clearGenres()


### PR DESCRIPTION
Videos with id starting with 2 would try to match Scoreland2 instead of Scoreland
Use ScorelandTwo as a work around and add abbreviation Scoreland2
Add Christy Marks when matching that site