### PR TITLE
Fix tgirls.porn Crashing When Parsing Release Date

### DIFF
--- a/Contents/Code/networkGrooby.py
+++ b/Contents/Code/networkGrooby.py
@@ -63,7 +63,11 @@ def update(metadata, lang, siteNum, movieGenres, movieActors):
     # Release Date
     dateNode = detailsPageElements.xpath('//div[@class="trailer_videoinfo"]//p[contains(., "Added")] | //div[@class="setdesc"]/*[contains(., "Added")]//following-sibling::text()')
     if dateNode:
-        date = dateNode[0].text_content().split('-', 1)[-1].strip()
+        if hasattr(dateNode[0], 'text_content'):
+            date = dateNode[0].text_content().split('-', 1)[-1].strip()
+        else:
+            date = dateNode[0].split('-', 1)[-1].strip()
+
         date_object = parse(date)
         metadata.originally_available_at = date_object
         metadata.year = metadata.originally_available_at.year

--- a/Contents/Code/networkGrooby.py
+++ b/Contents/Code/networkGrooby.py
@@ -61,17 +61,14 @@ def update(metadata, lang, siteNum, movieGenres, movieActors):
     metadata.collections.add(tagline)
 
     # Release Date
-    dateNode = detailsPageElements.xpath('//div[@class="trailer_videoinfo"]//p[contains(., "Added")] | //div[@class="setdesc"]/*[contains(., "Added")]//following-sibling::text()')
+    dateNode = detailsPageElements.xpath('//div[@class="setdesc"]/*[contains(., "Added")]//following-sibling::text()')
     if dateNode:
-        if hasattr(dateNode[0], 'text_content'):
-            date = dateNode[0].text_content().split('-', 1)[-1].strip()
-        else:
-            date = dateNode[0].split('-', 1)[-1].strip()
+        date = dateNode[0].split('-', 1)[-1].strip()
 
-        date_object = parse(date)
-        metadata.originally_available_at = date_object
-        metadata.year = metadata.originally_available_at.year
-    # There is probably a better way to set the release date out, but this works in my testing
+        if date:
+            date_object = parse(date)
+            metadata.originally_available_at = date_object
+            metadata.year = metadata.originally_available_at.year
 
     # Actors
     movieActors.clearActors()


### PR DESCRIPTION
Attempts to Refresh Metadata on scenes from tgirls.porn appear crash due to `dateNode[0]` not having a `text_content()` attribute

    _ElementStringResult has no attribute text_content

In function `search` in *networkGrooby.py*, the date is extracted from `dateNode[0]` without touching a `text_content()` attribute, so it's possible `search` was updated at some point previously to remove the call to `text_attribute()` and `update` was not updated.

In any case, to err on the side of caution with respect to other Grooby sites, this PR updates *networkGrooby.py* to access `dateNode[0].text_content()` only *if* the HTML that was returned from the xpath query contains such an attribute; otherwise, `dateNode[0]` is treated as being a string value already