### PR TITLE
Sometimes, the `Date: ` text is omitted, breaking the matching system…

### DIFF
--- a/Contents/Code/siteAlsAngels.py
+++ b/Contents/Code/siteAlsAngels.py
@@ -9,7 +9,7 @@ def search(results, lang, siteNum, searchData):
 
     if searchData.date:
         Log('*** date search')
-        parent = detailsPageElements.xpath('//tr[.//span[@class="videodate" and text()=\'Date: %s\']]' % searchData.dateFormat('%B %d, %Y'))
+        parent = detailsPageElements.xpath('//tr[.//span[@class="videodate" and contains(text(), "%s")]]' % searchData.dateFormat('%B %d, %Y'))
     elif searchData.title:
         Log('*** title search')
         m = re.search(r'([a-z0-9\&\; ]+) (masturbation|photoshoot|interview|girl-girl action|pov lapdance)', searchData.title, re.IGNORECASE)
@@ -44,7 +44,7 @@ def update(metadata, lang, siteNum, movieGenres, movieActors, art):
 
     req = PAutils.HTTPRequest(sceneURL)
     detailsPageElements = HTML.ElementFromString(req.text)
-    parentElement = detailsPageElements.xpath('//tr[.//span[@class="videodate" and text()=\'Date: %s\']]' % dateString)[0]
+    parentElement = detailsPageElements.xpath('//tr[.//span[@class="videodate" and contains(text(), "%s")]]' % dateString)[0]
 
     # Components
     model = re.sub(r'ALSAngels.com - (.+)', r'\1', detailsPageElements.xpath('//title')[0].text_content().strip(), flags=re.IGNORECASE)


### PR DESCRIPTION
…. Handle this by looking for the date string regardless of the `Date: ` prefix