### PR TITLE
Improve IAFD and Allow Refresh Metadata to Rotate Actor Images

### DIFF
--- a/Contents/Code/PAactors.py
+++ b/Contents/Code/PAactors.py
@@ -276,10 +276,10 @@ def getFromIAFD(actorName, actorEncoded, metadata):
         if actor.text_content():
             resultScore = Util.LevenshteinDistance(actorName.lower(), actor.text_content().strip().lower())
 
-            if resultScore != 0 and actorName.lower() in actorAlias[idx/2].text_content().lower():
+            if resultScore != 0 and actorName.lower() in actorAlias[idx / 2].text_content().lower():
                 resultScore = resultScore - 1
 
-            if metadata.studio.replace(' ', '').lower() in actorAlias[idx/2].replace(' ', '').text_content().lower():
+            if metadata.studio.replace(' ', '').lower() in actorAlias[idx / 2].replace(' ', '').text_content().lower():
                 resultScore = resultScore - 1
 
             if resultScore == score:

--- a/Contents/Code/PAactors.py
+++ b/Contents/Code/PAactors.py
@@ -63,7 +63,7 @@ class PhoenixActors:
                         actorName = newActor.strip()
                         displayActorName = actorName.replace('\xc2\xa0', '').strip()
 
-                        (actorPhoto, gender) = actorDBfinder(displayActorName)
+                        (actorPhoto, gender) = actorDBfinder(displayActorName, metadata)
                         Log('Actor: %s %s' % (displayActorName, actorPhoto))
                         Log('Gender: %s' % gender)
                         if Prefs['gender_enable']:
@@ -80,7 +80,7 @@ class PhoenixActors:
                         req = PAutils.HTTPRequest(actorPhoto, 'HEAD', bypass=False)
 
                     if not req or not req.ok:
-                        (actorPhoto, gender) = actorDBfinder(displayActorName)
+                        (actorPhoto, gender) = actorDBfinder(displayActorName, metadata)
                         Log('Gender: %s' % gender)
                         if Prefs['gender_enable']:
                             if gender == 'male':
@@ -100,7 +100,7 @@ class PhoenixActors:
                     role.photo = actorPhoto
 
 
-def actorDBfinder(actorName):
+def actorDBfinder(actorName, metadata):
     actorEncoded = urllib.quote(actorName)
 
     actorPhotoURL = ''
@@ -126,7 +126,7 @@ def actorDBfinder(actorName):
 
         url = None
         try:
-            (url, gender) = task(actorName, actorEncoded)
+            (url, gender) = task(actorName, actorEncoded, metadata)
         except Exception as e:
             Log.Error(format_exc())
 
@@ -155,7 +155,7 @@ def genderCheck(actorEncoded):
 
     return gender
 
-def getFromFreeones(actorName, actorEncoded):
+def getFromFreeones(actorName, actorEncoded, metadata):
     actorPhotoURL = ''
 
     req = PAutils.HTTPRequest('https://www.freeones.com/babes?q=' + actorEncoded)
@@ -197,7 +197,7 @@ def getFromFreeones(actorName, actorEncoded):
     return actorPhotoURL, 'female'
 
 
-def getFromIndexxx(actorName, actorEncoded):
+def getFromIndexxx(actorName, actorEncoded, metadata):
     actorPhotoURL = ''
 
     req = PAutils.HTTPRequest('https://www.indexxx.com/search/?query=' + actorEncoded)
@@ -215,7 +215,7 @@ def getFromIndexxx(actorName, actorEncoded):
     return actorPhotoURL, 'female'
 
 
-def getFromAdultDVDEmpire(actorName, actorEncoded):
+def getFromAdultDVDEmpire(actorName, actorEncoded, metadata):
     actorPhotoURL = ''
 
     req = PAutils.HTTPRequest('https://www.adultdvdempire.com/performer/search?q=' + actorEncoded)
@@ -232,7 +232,7 @@ def getFromAdultDVDEmpire(actorName, actorEncoded):
     return actorPhotoURL, ''
 
 
-def getFromBoobpedia(actorName, actorEncoded):
+def getFromBoobpedia(actorName, actorEncoded, metadata):
     actorPhotoURL = ''
 
     actorPageURL = 'http://www.boobpedia.com/boobs/' + actorName.title().replace(' ', '_')
@@ -245,7 +245,7 @@ def getFromBoobpedia(actorName, actorEncoded):
     return actorPhotoURL, 'female'
 
 
-def getFromBabesandStars(actorName, actorEncoded):
+def getFromBabesandStars(actorName, actorEncoded, metadata):
     actorPhotoURL = ''
 
     actorPageURL = 'http://www.babesandstars.com/' + actorName[0:1].lower() + '/' + actorName.lower().replace(' ', '-').replace('\'', '-') + '/'
@@ -258,14 +258,40 @@ def getFromBabesandStars(actorName, actorEncoded):
     return actorPhotoURL, 'female'
 
 
-def getFromIAFD(actorName, actorEncoded):
+def getFromIAFD(actorName, actorEncoded, metadata):
     actorPhotoURL = ''
     gender = ''
+    results = []
     req = PAutils.HTTPRequest('http://www.iafd.com/results.asp?searchtype=comprehensive&searchstring=' + actorEncoded)
+
     actorSearch = HTML.ElementFromString(req.text)
-    actorPageURL = actorSearch.xpath('//table[@id="tblFem" or @id="tblMal"]//tbody//a/@href')
+    actorResults = actorSearch.xpath('//table[@id="tblFem" or @id="tblMal"]//tbody//a')
+    actorAlias = actorSearch.xpath('//table[@id="tblFem" or @id="tblMal"]//tbody//td[@class="text-left"]')
+
+    score = Util.LevenshteinDistance(actorName.lower(), actorResults[0].text_content().strip().lower()) + 1
+
+    for idx, actor in enumerate(actorResults, 0):
+        if actor.text_content():
+            resultScore = Util.LevenshteinDistance(actorName.lower(), actor.text_content().strip().lower())
+
+            if resultScore != 0 and actorName.lower() in actorAlias[idx/2].text_content().lower():
+                resultScore = resultScore - 1
+
+            if metadata.studio.replace(' ', '').lower() in actorAlias[idx/2].replace(' ', '').text_content().lower():
+                resultScore = resultScore - 1
+
+            if resultScore == score:
+                results.append(actor.xpath('./@href')[0])
+
+            if resultScore < score:
+                del results[:]
+                score = resultScore
+                results.append(actor.xpath('./@href')[0])
+
+    actorPageURL = random.choice(results)
+
     if actorPageURL:
-        actorPageURL = 'http://www.iafd.com' + actorPageURL[0]
+        actorPageURL = 'http://www.iafd.com' + actorPageURL
         req = PAutils.HTTPRequest(actorPageURL)
         actorPage = HTML.ElementFromString(req.text)
         img = actorPage.xpath('//div[@id="headshot"]//img/@src')
@@ -277,7 +303,7 @@ def getFromIAFD(actorName, actorEncoded):
     return actorPhotoURL, gender
 
 
-def getFromBabepedia(actorName, actorEncoded):
+def getFromBabepedia(actorName, actorEncoded, metadata):
     actorPhotoURL = ''
 
     img = 'http://www.babepedia.com/pics/%s.jpg' % urllib.quote(actorName.title())
@@ -288,7 +314,7 @@ def getFromBabepedia(actorName, actorEncoded):
     return actorPhotoURL, 'female'
 
 
-def getFromLocalStorage(actorName, actorEncoded):
+def getFromLocalStorage(actorName, actorEncoded, metadata):
     actorPhotoURL = ''
 
     actorsResourcesPath = os.path.join(Core.bundle_path, 'Contents', 'Resources')

--- a/Contents/Code/PAactors.py
+++ b/Contents/Code/PAactors.py
@@ -143,6 +143,7 @@ def actorDBfinder(actorName, metadata):
 
     return actorPhotoURL, gender
 
+
 def genderCheck(actorEncoded):
     gender = ''
 
@@ -154,6 +155,7 @@ def genderCheck(actorEncoded):
         gender = 'male' if 'gender=m' in actorPageURL[0] else 'female'
 
     return gender
+
 
 def getFromFreeones(actorName, actorEncoded, metadata):
     actorPhotoURL = ''


### PR DESCRIPTION
- Better Matching Instead of choosing First Result
- Collect Best Matches and Chooses Random Image if Multiple Matches (Refresh Metadate will rotate until happy)
- Look for Name is Aliases
- Look for Studio Name in Aliases for Site Based AKA

Example Anna Blaze pulls Brianna Blaze image (is fixed with this change)
Example Name in IAFD is Marie (tons of results)...Can keep refreshing until match is made