### PR TITLE
Add use the agent in Personal Media (Other Videos)

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -50,7 +50,7 @@ def ValidatePrefs():
 class PhoenixAdultAgent(Agent.Movies):
     name = 'PhoenixAdult'
     languages = [Locale.Language.NoLanguage, Locale.Language.English, Locale.Language.German, Locale.Language.French, Locale.Language.Spanish, Locale.Language.Italian, Locale.Language.Dutch]
-    accepts_from = [ 'com.plexapp.agents.localmedia', 'com.plexapp.agents.lambda']
+    accepts_from = ['com.plexapp.agents.localmedia', 'com.plexapp.agents.lambda']
     contributes_to = ['com.plexapp.agents.none', 'com.plexapp.agents.stashplexagent', 'com.plexapp.agents.themoviedb', 'com.plexapp.agents.imdb']
     primary_provider = True
 

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -49,12 +49,15 @@ def ValidatePrefs():
 
 class PhoenixAdultAgent(Agent.Movies):
     name = 'PhoenixAdult'
-    languages = [Locale.Language.English, Locale.Language.German, Locale.Language.French, Locale.Language.Spanish, Locale.Language.Italian, Locale.Language.Dutch]
-    accepts_from = ['com.plexapp.agents.localmedia', 'com.plexapp.agents.lambda']
-    contributes_to = ['com.plexapp.agents.stashplexagent', 'com.plexapp.agents.themoviedb', 'com.plexapp.agents.imdb']
+    languages = [Locale.Language.NoLanguage, Locale.Language.English, Locale.Language.German, Locale.Language.French, Locale.Language.Spanish, Locale.Language.Italian, Locale.Language.Dutch]
+    accepts_from = [ 'com.plexapp.agents.localmedia', 'com.plexapp.agents.lambda']
+    contributes_to = ['com.plexapp.agents.none', 'com.plexapp.agents.stashplexagent', 'com.plexapp.agents.themoviedb', 'com.plexapp.agents.imdb']
     primary_provider = True
 
     def search(self, results, media, lang):
+        if not media.name and media.primary_metadata.title:
+            media.name = media.primary_metadata.title
+
         title = PAutils.getSearchTitleStrip(media.name)
         title = PAutils.getCleanSearchTitle(title)
 


### PR DESCRIPTION
When set as personal media's agent, the `media.name` and `media.filename` in the search function would be `None`. Get the media name from `primary_metadata`.

Users can set this agent above the Personal Media in the Agent menu, and get the landscape view from the web and apps.

Might help on solving https://github.com/PAhelper/PhoenixAdult.bundle/issues/1400