### PR TITLE
Remove Actor Photo URL to Prevent xpath Exception

### DIFF
--- a/Contents/Code/siteData18Scenes.py
+++ b/Contents/Code/siteData18Scenes.py
@@ -213,7 +213,7 @@ def update(metadata, lang, siteNum, movieGenres, movieActors, art):
     actors = detailsPageElements.xpath('//h3[contains(., "Cast")]//following::div//a[contains(@href, "/name/")]/img')
     for actorLink in actors:
         actorName = actorLink.xpath('./@alt')[0].strip()
-        actorPhotoURL = actorLink.xpath('./(@data-src|@src)')[0].strip()
+        actorPhotoURL = ''
 
         if actorName:
             movieActors.addActor(actorName, actorPhotoURL)

--- a/Contents/Code/siteData18Scenes.py
+++ b/Contents/Code/siteData18Scenes.py
@@ -215,6 +215,10 @@ def update(metadata, lang, siteNum, movieGenres, movieActors, art):
         actorName = actorLink.xpath('./@alt')[0].strip()
         actorPhotoURL = ''
 
+        actorPhotoNode = actorLink.xpath('./@data-src')
+        if actorPhotoNode:
+            actorPhotoURL = actorPhotoNode[0].strip()
+
         if actorName:
             movieActors.addActor(actorName, actorPhotoURL)
 


### PR DESCRIPTION
The actor photos require a referrer to retrieve from data18.com, so it's pointless to try and grab them as they will always fail and use a fallback actor image source.

#1547