### PR TITLE
Fix possible undefined actor poster

### DIFF
--- a/Contents/Code/siteXConfessions.py
+++ b/Contents/Code/siteXConfessions.py
@@ -89,7 +89,10 @@ def update(metadata, lang, siteNum, movieGenres, movieActors, art):
     movieActors.clearActors()
     for actorLink in detailsPageElements['performers']:
         actorName = '%s %s' % (actorLink['name'], actorLink['last_name'])
-        actorPhotoURL = actorLink['poster_image'].split('?', 1)[0]
+        if actorLink['poster_image'] is not None:
+            actorPhotoURL = actorLink['poster_image'].split('?', 1)[0]
+        else:
+            actorPhotoURL = ''
         movieActors.addActor(actorName, actorPhotoURL)
 
     # Director


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/68063884/177141894-de3d4bc8-29ac-4562-9ba8-35fedf6f8617.png)

```
2022-07-04 12:48:49,882 (7f8a38713b38) :  CRITICAL (agentkit:1095) - Exception in the update function of agent named 'PhoenixAdult', called with guid 'com.plexapp.agents.phoenixadult://hot-pot-3-way|695?lang=en' (most recent call last):
  File "/usr/lib/plexmediaserver/Resources/Plug-ins-6b0e31a64/Framework.bundle/Contents/Resources/Versions/2/Python/Framework/api/agentkit.py", line 1093, in _update
    agent.update(obj, media, lang, **kwargs)
  File "/config/Library/Application Support/Plex Media Server/Plug-ins/PhoenixAdult.bundle/Contents/Code/__init__.py", line 142, in update
    provider.update(metadata, lang, siteNum, movieGenres, movieActors, valid_images)
  File "/config/Library/Application Support/Plex Media Server/Plug-ins/PhoenixAdult.bundle/Contents/Code/siteXConfessions.py", line 92, in update
    actorPhotoURL = actorLink['poster_image'].split('?', 1)[0]
AttributeError: 'NoneType' object has no attribute 'split'

```