### PR TITLE
Naughty America: Fix Direct Search Date Error (No Longer Timestamp)

### DIFF
--- a/Contents/Code/PAsiteList.py
+++ b/Contents/Code/PAsiteList.py
@@ -527,7 +527,7 @@ searchSites = {
     338: ('Massage Rooms', 'https://www.sexyhub.com', 'https://site-api.project1service.com'),
     339: ('MomXXX', 'https://www.sexyhub.com', 'https://site-api.project1service.com'),
     340: ('FakeHub', 'https://www.fakehub.com', 'https://site-api.project1service.com'),
-    341: ('Big Cock Bully', 'https://tour.naughtyamerica.com', 'https://i6p9q9r18e-3.algolianet.com/1/indexes/*/queries'),
+    341: ('Thundercock', 'https://tour.naughtyamerica.com', 'https://i6p9q9r18e-3.algolianet.com/1/indexes/*/queries'),
     342: ('VirtualRealPorn', 'https://virtualrealporn.com', '/vr-porn-video/'),
     343: ('Analized', 'https://analized.com', '/1/search/'),
     344: ('James Deen', 'https://jamesdeen.com', '/1/search/'),

--- a/Contents/Code/PAsiteList.py
+++ b/Contents/Code/PAsiteList.py
@@ -1658,6 +1658,7 @@ searchSites = {
     1569: ('Big Cock Hero', 'https://tour.naughtyamerica.com', 'https://i6p9q9r18e-3.algolianet.com/1/indexes/*/queries'),
     1570: ('Mom\'s Money', 'https://tour.naughtyamerica.com', 'https://i6p9q9r18e-3.algolianet.com/1/indexes/*/queries'),
     1571: ('College Sugarbabes', 'https://tour.naughtyamerica.com', 'https://i6p9q9r18e-3.algolianet.com/1/indexes/*/queries'),
+    1572: ('Mrs. Creampie', 'https://tour.naughtyamerica.com', 'https://i6p9q9r18e-3.algolianet.com/1/indexes/*/queries'),
 }
 
 abbreviations = (
@@ -1818,6 +1819,7 @@ abbreviations = (
     ('^mr ', 'MassageRooms '),
     ('^mrpov ', 'MisterPOV'),
     ('^mrs ', 'MassageRooms '),
+    ('^mrsc ', 'MrsCreampie '),
     ('^mshf ', 'MySistersHotFriend '),
     ('^mts ', 'MomsTeachSex '),
     ('^mvft ', 'MyVeryFirstTime '),
@@ -1936,7 +1938,7 @@ def getProviderFromSiteNum(siteNum):
             provider = networkMetadataAPI
 
         # Naughty America
-        elif (5 <= siteNum <= 51) or siteNum == 341 or (393 <= siteNum <= 396) or (467 <= siteNum <= 468) or siteNum == 581 or siteNum == 620 or siteNum == 625 or siteNum == 691 or siteNum == 749 or (1569 <= siteNum <= 1570):
+        elif (5 <= siteNum <= 51) or siteNum == 341 or (393 <= siteNum <= 396) or (467 <= siteNum <= 468) or siteNum == 581 or siteNum == 620 or siteNum == 625 or siteNum == 691 or siteNum == 749 or (1569 <= siteNum <= 1572):
             provider = siteNaughtyAmerica
 
         # Vixen

--- a/Contents/Code/PAsiteList.py
+++ b/Contents/Code/PAsiteList.py
@@ -527,7 +527,7 @@ searchSites = {
     338: ('Massage Rooms', 'https://www.sexyhub.com', 'https://site-api.project1service.com'),
     339: ('MomXXX', 'https://www.sexyhub.com', 'https://site-api.project1service.com'),
     340: ('FakeHub', 'https://www.fakehub.com', 'https://site-api.project1service.com'),
-    341: ('Thundercock', 'https://tour.naughtyamerica.com', 'https://i6p9q9r18e-3.algolianet.com/1/indexes/*/queries'),
+    341: ('Big Cock Bully', 'https://tour.naughtyamerica.com', 'https://i6p9q9r18e-3.algolianet.com/1/indexes/*/queries'),
     342: ('VirtualRealPorn', 'https://virtualrealporn.com', '/vr-porn-video/'),
     343: ('Analized', 'https://analized.com', '/1/search/'),
     344: ('James Deen', 'https://jamesdeen.com', '/1/search/'),
@@ -1659,6 +1659,7 @@ searchSites = {
     1570: ('Mom\'s Money', 'https://tour.naughtyamerica.com', 'https://i6p9q9r18e-3.algolianet.com/1/indexes/*/queries'),
     1571: ('College Sugarbabes', 'https://tour.naughtyamerica.com', 'https://i6p9q9r18e-3.algolianet.com/1/indexes/*/queries'),
     1572: ('Mrs. Creampie', 'https://tour.naughtyamerica.com', 'https://i6p9q9r18e-3.algolianet.com/1/indexes/*/queries'),
+    1573: ('Thundercock', 'https://tour.naughtyamerica.com', 'https://i6p9q9r18e-3.algolianet.com/1/indexes/*/queries'),
 }
 
 abbreviations = (
@@ -1938,7 +1939,7 @@ def getProviderFromSiteNum(siteNum):
             provider = networkMetadataAPI
 
         # Naughty America
-        elif (5 <= siteNum <= 51) or siteNum == 341 or (393 <= siteNum <= 396) or (467 <= siteNum <= 468) or siteNum == 581 or siteNum == 620 or siteNum == 625 or siteNum == 691 or siteNum == 749 or (1569 <= siteNum <= 1572):
+        elif (5 <= siteNum <= 51) or siteNum == 341 or (393 <= siteNum <= 396) or (467 <= siteNum <= 468) or siteNum == 581 or siteNum == 620 or siteNum == 625 or siteNum == 691 or siteNum == 749 or (1569 <= siteNum <= 1573):
             provider = siteNaughtyAmerica
 
         # Vixen

--- a/Contents/Code/PAsiteList.py
+++ b/Contents/Code/PAsiteList.py
@@ -1657,6 +1657,7 @@ searchSites = {
     1568: ('GayHoopla', 'https://www.gayhoopla.com', '/videos/search?s='),
     1569: ('Big Cock Hero', 'https://tour.naughtyamerica.com', 'https://i6p9q9r18e-3.algolianet.com/1/indexes/*/queries'),
     1570: ('Mom\'s Money', 'https://tour.naughtyamerica.com', 'https://i6p9q9r18e-3.algolianet.com/1/indexes/*/queries'),
+    1571: ('College Sugarbabes', 'https://tour.naughtyamerica.com', 'https://i6p9q9r18e-3.algolianet.com/1/indexes/*/queries'),
 }
 
 abbreviations = (

--- a/Contents/Code/PAsiteList.py
+++ b/Contents/Code/PAsiteList.py
@@ -1656,6 +1656,7 @@ searchSites = {
     1567: ('BiGuysFuck', 'https://www.biguysfuck.com', '/videos/search?s='),
     1568: ('GayHoopla', 'https://www.gayhoopla.com', '/videos/search?s='),
     1569: ('Big Cock Hero', 'https://tour.naughtyamerica.com', 'https://i6p9q9r18e-3.algolianet.com/1/indexes/*/queries'),
+    1570: ('Mom\'s Money', 'https://tour.naughtyamerica.com', 'https://i6p9q9r18e-3.algolianet.com/1/indexes/*/queries'),
 }
 
 abbreviations = (
@@ -1934,7 +1935,7 @@ def getProviderFromSiteNum(siteNum):
             provider = networkMetadataAPI
 
         # Naughty America
-        elif (5 <= siteNum <= 51) or siteNum == 341 or (393 <= siteNum <= 396) or (467 <= siteNum <= 468) or siteNum == 581 or siteNum == 620 or siteNum == 625 or siteNum == 691 or siteNum == 749 or siteNum == 1569:
+        elif (5 <= siteNum <= 51) or siteNum == 341 or (393 <= siteNum <= 396) or (467 <= siteNum <= 468) or siteNum == 581 or siteNum == 620 or siteNum == 625 or siteNum == 691 or siteNum == 749 or (1569 <= siteNum <= 1570):
             provider = siteNaughtyAmerica
 
         # Vixen

--- a/Contents/Code/PAsiteList.py
+++ b/Contents/Code/PAsiteList.py
@@ -1655,6 +1655,7 @@ searchSites = {
     1566: ('HotGuysFuck', 'https://www.hotguysfuck.com', '/videos/search?s='),
     1567: ('BiGuysFuck', 'https://www.biguysfuck.com', '/videos/search?s='),
     1568: ('GayHoopla', 'https://www.gayhoopla.com', '/videos/search?s='),
+    1569: ('Big Cock Hero', 'https://tour.naughtyamerica.com', 'https://i6p9q9r18e-3.algolianet.com/1/indexes/*/queries'),
 }
 
 abbreviations = (
@@ -1933,7 +1934,7 @@ def getProviderFromSiteNum(siteNum):
             provider = networkMetadataAPI
 
         # Naughty America
-        elif (5 <= siteNum <= 51) or siteNum == 341 or (393 <= siteNum <= 396) or (467 <= siteNum <= 468) or siteNum == 581 or siteNum == 620 or siteNum == 625 or siteNum == 691 or siteNum == 749:
+        elif (5 <= siteNum <= 51) or siteNum == 341 or (393 <= siteNum <= 396) or (467 <= siteNum <= 468) or siteNum == 581 or siteNum == 620 or siteNum == 625 or siteNum == 691 or siteNum == 749 or siteNum == 1569:
             provider = siteNaughtyAmerica
 
         # Vixen

--- a/Contents/Code/siteNaughtyAmerica.py
+++ b/Contents/Code/siteNaughtyAmerica.py
@@ -47,7 +47,7 @@ def search(results, lang, siteNum, searchData):
         sceneID = None
 
     url = PAsearchSites.getSearchSearchURL(siteNum) + '?x-algolia-application-id=I6P9Q9R18E&x-algolia-api-key=08396b1791d619478a55687b4deb48b4'
-    if sceneID and not searchData.title:
+    if sceneID:
         searchResults = [getNaughtyAmerica(sceneID)]
     else:
         searchResults = getAlgolia(url, 'nacms_combined_production', 'query=' + searchData.title)
@@ -55,7 +55,7 @@ def search(results, lang, siteNum, searchData):
     for searchResult in searchResults:
         titleNoFormatting = PAutils.parseTitle(searchResult['title'], siteNum)
         curID = searchResult['id']
-        releaseDate = datetime.fromtimestamp(searchResult['published_at']).strftime('%Y-%m-%d')
+        releaseDate = searchResult['published_at'].strftime('%Y-%m-%d')
         siteName = searchResult['site']
 
         if sceneID:

--- a/Contents/Code/siteNaughtyAmerica.py
+++ b/Contents/Code/siteNaughtyAmerica.py
@@ -88,8 +88,9 @@ def update(metadata, lang, siteNum, movieGenres, movieActors, art):
 
     # Tagline and Collection(s)
     metadata.collections.clear()
-    metadata.collections.add(metadata.studio)
-    metadata.collections.add(detailsPageElements['site'])
+    tagline = detailsPageElements['site']
+    metadata.tagline = tagline
+    metadata.collections.add(tagline)
 
     # Release Date
     date_object = detailsPageElements['published_at']

--- a/docs/sitelist.md
+++ b/docs/sitelist.md
@@ -756,6 +756,7 @@ If you're having difficulty finding the SceneID, double-check [PAsiteList.py](..
   - Asian 1 on 1
   - Ass Masterpiece
   - Big Cock Bully
+  - College Sugarbabes
   - Diary of a Milf
   - Diary of a Nanny
   - Dirty Wives Club
@@ -774,6 +775,7 @@ If you're having difficulty finding the SceneID, double-check [PAsiteList.py](..
   - Live Naughty Teacher
   - Live Party Girl
   - Milf Sugar Babes Classic
+  - Mom's Money
   - My Dads Hot Girlfriend
   - My Daughters Hot Friend
   - My First Sex Teacher

--- a/docs/sitelist.md
+++ b/docs/sitelist.md
@@ -776,6 +776,7 @@ If you're having difficulty finding the SceneID, double-check [PAsiteList.py](..
   - Live Party Girl
   - Milf Sugar Babes Classic
   - Mom's Money
+  - Mrs. Creampie
   - My Dads Hot Girlfriend
   - My Daughters Hot Friend
   - My First Sex Teacher


### PR DESCRIPTION
Removed text check if scene ID used, since Algolia (https://i6p9q9r18e-3.algolianet.com/1/indexes/*/queries) link is dead making direct the only working search method.

Fixes #1587