### PR TITLE
Move JavBus Image Search Names to Database

### DIFF
--- a/Contents/Code/PAactors.py
+++ b/Contents/Code/PAactors.py
@@ -324,20 +324,17 @@ def getFromBabepedia(actorName, actorEncoded, metadata):
 def getFromJAVBus(actorName, actorEncoded, metadata):
     actorPhotoURL = ''
 
-    hepburnSearchPairs = {
-        ('June Lovejoy', 'Zyuun rabuzyoi'), ('Melody Marks', 'Merodei hiina makusu'), ('Lily Heart', 'Ririi haato'), ('Washio Mei', 'Wasio mei')
-    }
-
-    for value in hepburnSearchPairs:
-        if value[0].lower() == actorName.lower():
-            actorEncoded = urllib.quote(value[1])
+    for actorSeachName, names in PAdatabaseActors.actorsReplaceJavBusSearch.items():
+        if actorName.lower() in map(str.lower, names):
+            actorEncoded = urllib.quote(actorSeachName)
+            break
 
     req = PAutils.HTTPRequest('https://www.javbus.com/en/searchstar/' + actorEncoded)
     actorSearch = HTML.ElementFromString(req.text)
     img = actorSearch.xpath('//div[@class="photo-frame"]//img/@src')
     if img:
         if 'nowprinting' not in img[0]:
-            actorPhotoURL = 'https://www.javbus.com/' + img[0]
+            actorPhotoURL = 'https://www.javbus.com' + img[0]
 
     return actorPhotoURL, 'female'
 

--- a/Contents/Code/PAdatabaseActors.py
+++ b/Contents/Code/PAdatabaseActors.py
@@ -5555,3 +5555,16 @@ ActorsStudioIndexes = {
     62: ['Allure Media'],
     63: ['PornPros'],
 }
+
+
+actorsReplaceJavBusSearch = {
+    'Zyuun rabuzyoi': ['June Lovejoy'],
+    'Merodei hiina makusu': ['Melody Marks'],
+    'Ririi haato': ['Lily Heart'],
+    'Wasio mei': ['Washio Mei'],
+    'Nanzyou itika': ['Nanjou Ichika'],
+    'Nana Matsumoto': ['Matsumoto Nanami'],
+    'Huzisawa reo': ['Fujisawa Rio'],
+    'Mizuho Nagayama': ['Eiyama Mizuho'],
+    'Nagata riu': ['Nagata Reiame'],
+}


### PR DESCRIPTION
Originally thought this was only going to be an issue with western names...apparently not. Moving to database to reduce clutter. 

Intention is to not use the English name from JavBus as it is not correct.