### PR TITLE
LittleCaprice changes

### DIFF
--- a/Contents/Code/PAdatabaseActors.py
+++ b/Contents/Code/PAdatabaseActors.py
@@ -238,6 +238,7 @@ ActorsReplace = {
 
 ActorsReplaceStudios = {
     0: {  # 21 Sextury, 21Sextury, Footsie Babes
+        'Eva Smolina': ['Una'],
         'Henessy': ['Henna Ssy'],
         'Jessy Nikea': ['Nikea'],
         'Katarina Muti': ['Ariel Temple'],

--- a/Contents/Code/PAdatabaseActors.py
+++ b/Contents/Code/PAdatabaseActors.py
@@ -241,6 +241,7 @@ ActorsReplaceStudios = {
         'Henessy': ['Henna Ssy'],
         'Jessy Nikea': ['Nikea'],
         'Katarina Muti': ['Ariel Temple'],
+        'Kate Shira': ['Shira'],
         'Krystal Boyd': ['Abbie'],
         'Lina Arian Joy': ['Arian'],
         'Mishelle Klein': ['Molly A'],

--- a/Contents/Code/PAsiteList.py
+++ b/Contents/Code/PAsiteList.py
@@ -1806,6 +1806,14 @@ searchSites = {
     1710: ('Bride 4K', 'https://vip4k.com', '/en/search/'),
     1711: ('Dyke 4K', 'https://vip4k.com', '/en/search/'),
     1712: ('Ignore 4K', 'https://vip4k.com', '/en/search/'),
+    1713: ('Buttmuse', 'https://www.littlecaprice-dreams.com', '/?s='),
+    1714: ('Caprice Divas', 'https://www.littlecaprice-dreams.com', '/?s='),
+    1715: ('NasstyX', 'https://www.littlecaprice-dreams.com', '/?s='),
+    1716: ('POVDreams', 'https://www.littlecaprice-dreams.com', '/?s='),
+    1717: ('Streetfuck', 'https://www.littlecaprice-dreams.com', '/?s='),
+    1718: ('SuperprivateX', 'https://www.littlecaprice-dreams.com', '/?s='),
+    1719: ('Wecumtoyou', 'https://www.littlecaprice-dreams.com', '/?s='),
+    1720: ('Xpervo', 'https://www.littlecaprice-dreams.com', '/?s='),
 }
 
 abbreviations = (
@@ -2504,7 +2512,7 @@ def getProviderFromSiteNum(siteNum):
             provider = siteStraplezz
 
         # LittleCaprice
-        elif siteNum == 742:
+        elif siteNum == 742 or (1713 <= siteNum <= 1720):
             provider = siteLittleCaprice
 
         # WowGirls

--- a/docs/sitelist.md
+++ b/docs/sitelist.md
@@ -703,6 +703,14 @@ If you're having difficulty finding the SceneID, double-check [PAsiteList.py](..
   - WiredPussy
 + #### Kinky Spa | ✓
 + #### Little Caprice | ✅
+  - Buttmuse
+  - Caprice Divas
+  - NasstyX
+  - POVDreams
+  - Streetfuck
+  - SuperprivateX
+  - Wecumtoyou
+  - Xpervo
 + #### Look At Her Now | ✅
 + #### LoveHerFilms | ✅
   - LoveHerBoobs


### PR DESCRIPTION
Fixed LittleCaprice. 

This one is a bit weird. With the latest site change search results now link to the gallery page of the scene, which does not contain a lot of metadata, but it does contain pictures. There is a separate video page linked in the gallery page which does not contain a lot of images but has more relavant metadata (description, genres etc). The title and the date in these two pages can be slightly different. The search function will search and gather info from the gallery pages but the update function will use details from the video page (when avaliable).

Also added support for the sub-site names:
  - Buttmuse
  - Caprice Divas
  - NasstyX
  - POVDreams
  - Streetfuck
  - SuperprivateX
  - Wecumtoyou
  - Xpervo