### PR TITLE
Use date against 'Newest scenes' to get accurate scene matching

### DIFF
--- a/Contents/Code/networkPornWorld.py
+++ b/Contents/Code/networkPornWorld.py
@@ -18,6 +18,9 @@ def search(results, lang, siteNum, searchData):
         delta = date.today() - searchDateObj
         searchPage = math.ceil(float(delta.days) / 99)
 
+        # the first word in the title is usually a name
+        searchName = searchData.title.lower().split()[0]
+
         # Log('Scene date: %s, Days delta: %d, Page: %d' % (searchData.date, delta.days, searchPage))
 
         searchUrl = 'https://www.pornworld.com/new-videos/%d'
@@ -59,11 +62,12 @@ def search(results, lang, siteNum, searchData):
                     # take off some points if the date is not a precise match
                     score = 100 - daysDiff * 10
 
-                    # take off some points if we don't match the title search params
-                    if not searchData.title.lower() in titleNoFormatting.lower():
+                    # try to match the first word/name in the title
+                    if not searchName in titleNoFormatting.lower():
+                        # take off some points if we don't match the title search params
                         score = score - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
-                    # names can be obscure so output the date too
+                    # scene names can be obscure so output the date too
                     name = '%s %s' % (sceneDate, titleNoFormatting)
 
                     results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name=name, score=score, lang=lang))

--- a/Contents/Code/networkPornWorld.py
+++ b/Contents/Code/networkPornWorld.py
@@ -18,7 +18,7 @@ def search(results, lang, siteNum, searchData):
         delta = date.today() - searchDateObj
         searchPage = math.ceil(float(delta.days) / 99)
 
-        # Log('PWDebug: Scene date: %s, Days delta: %d, Page: %d' % (searchData.date, delta.days, searchPage))
+        # Log('Scene date: %s, Days delta: %d, Page: %d' % (searchData.date, delta.days, searchPage))
 
         searchUrl = 'https://www.pornworld.com/new-videos/%d'
         dateNotFound = True
@@ -117,8 +117,10 @@ def search(results, lang, siteNum, searchData):
 
     return results
 
+
 def dateFromIso(dateString):
     return datetime.strptime(dateString, '%Y-%m-%d').date()
+
 
 def update(metadata, lang, siteNum, movieGenres, movieActors, art):
     metadata_id = str(metadata.id).split('|')

--- a/Contents/Code/networkPornWorld.py
+++ b/Contents/Code/networkPornWorld.py
@@ -54,7 +54,6 @@ def search(results, lang, siteNum, searchData):
 
                 # let's allow scenes +/- two days of the target date as sometimes scenes get re-dated on the site
                 if daysDiff < 3:
-                    Log('Scene: %s %s' % (sceneDate, titleNoFormatting))
 
                     url = searchResult.xpath('.//a/@href')[0]
                     curID = PAutils.Encode(url)
@@ -63,9 +62,11 @@ def search(results, lang, siteNum, searchData):
                     score = 100 - daysDiff * 10
 
                     # try to match the first word/name in the title
-                    if not searchName in titleNoFormatting.lower():
+                    if searchName not in titleNoFormatting.lower():
                         # take off some points if we don't match the title search params
                         score = score - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
+
+                    Log('Scene: %s %s (%s%%)' % (sceneDate, titleNoFormatting, score))
 
                     # scene names can be obscure so output the date too
                     name = '%s %s' % (sceneDate, titleNoFormatting)


### PR DESCRIPTION
With most videos being released with titles in the format `Pornworld.23.03.16.Shalina.Devine...`, the current system does a terrible job at trying to get suitable matches, due to the equally terrible search system in use by the site. Instead, let's take that date info and use it against the 'Newest scenes' pages, where the most recent 99 scenes are on page 1 and all previous scenes are on subsequent pages. We'll try to make an intelligent guess for which page to scan, and jump to other pages as necessary until we find an approximate date match, then return results that are hopefully relevant. If we get a date match and the search title is a substring of the found result, that's a 100% match.