### PR TITLE
Improve plural variant handling

### DIFF
--- a/Contents/Code/networkPornPros.py
+++ b/Contents/Code/networkPornPros.py
@@ -15,13 +15,16 @@ def search(results, lang, siteNum, searchData):
         if '/video/' in sceneURL and sceneURL not in searchResults:
             searchResults.append(sceneURL)
 
-    searchResults = list(dict.fromkeys([sceneURL.replace('www.', '', 1) for sceneURL in searchResults]))
-
+    pluralResults = list(searchResults)
     for sceneURL in searchResults:
         if sceneURL == directURL.replace('www.', '', 1):
             for original, new in plurals.items():
                 sceneURL = sceneURL.replace(original, new)
+            pluralResults.append(sceneURL)
 
+    searchResults = list(dict.fromkeys([sceneURL.replace('www.', '', 1) for sceneURL in pluralResults]))
+
+    for sceneURL in searchResults:
         req = PAutils.HTTPRequest(sceneURL)
         if 'signup.' not in req.url:
             detailsPageElements = HTML.ElementFromString(req.text)


### PR DESCRIPTION
Within the search function, the sceneURL is compared to directURL. If they are the same, then we replace plurals. ie. sisters become sister-s. This is problematic because we always turn sisters into sister-s even if the url is actually sisters. This makes the scene unsearchable.

Mitigate this case by searching both the plurals substituted and original sceneURL.

- Make a copy of searchResults called pluralResults
- Process the plurals, at the end append to pluralReults
- Remove duplicates from pluralResults and assign back to searchResults