### PR TITLE
Improve XConfessions

### DIFF
--- a/Contents/Code/siteXConfessions.py
+++ b/Contents/Code/siteXConfessions.py
@@ -48,6 +48,16 @@ def search(results, lang, siteNum, searchData):
 
                 results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s' % (titleNoFormatting), score=score, lang=lang))
 
+        # Also try to get a direct match from the title slug
+        slug = searchData.title.replace(' ', '-').lower()
+        directMatch = getDatafromAPI(PAsearchSites.getSearchBaseURL(siteNum), slug, token, False)
+        if directMatch:
+            curID = directMatch['slug']
+            titleNoFormatting = directMatch['title']
+            # This is a perfect match, so give it a perfect score
+            score = 100
+            results.Append(MetadataSearchResult(id='%s|%d' % (curID, siteNum), name='%s' % (titleNoFormatting), score=score, lang=lang))
+
     return results
 
 

--- a/postprocessing2/PAsearchSites.py
+++ b/postprocessing2/PAsearchSites.py
@@ -702,7 +702,7 @@ searchSites[691] = ("Watch Your Mom", "Watch Your Mom", "https://tour.naughtyame
 searchSites[692] = ("Butt Plays", "Butt Plays", "http://www.21sextury.com", "https://tsmkfa364q-dsn.algolia.net/1/indexes/*/queries")
 searchSites[693] = ("Dorcel Vision", "Dorcel Vision", "https://www.dorcelvision.com", "https://www.dorcelvision.com/en/search?type=4&keyword=")
 searchSites[694] = ("Feminized", "Feminized", "http://feminized.com", "http://feminized.com/tour/search.php?st=advanced&qany=")
-searchSites[695] = ("XConfessions", "XConfessions", "https://xconfessions.com", "https://xconfessions.com/api/search")
+searchSites[695] = ("XConfessions", "XConfessions", "https://api.xconfessions.com", "https://api.xconfessions.com/api/search")
 searchSites[696] = ("Czech Amateurs", "Czech Amateurs", "https://czechamateurs.com", "https://czechamateurs.com/tour/search/?q=")
 searchSites[697] = ("Czech Bangbus", "Czech Bangbus", "https://czechbangbus.com", "https://czechbangbus.com/tour/search/?q=")
 searchSites[698] = ("Czech Bitch", "Czech Bitch", "https://czechbitch.com", "https://czechbitch.com/tour/search/?q=")


### PR DESCRIPTION
## Context

Sometimes their search is misbehaving. I already handled this with their support multiple times, it ends up getting fixed, but it takes time and effort. In those cases, it helps trying to get the movie directly via its official slug. This is a good and clean work around imho.

### Example:
- Filename: `XConfessions - private-dancer`
- Slug: `private-dancer`


## Technical data
### Valid search: `A man of faith`
```sh
# Searching for `a man of faith`
curl -X POST 'https://api.xconfessions.com/api/search?query=a+man+of+faith'
    | jq 'map(select(.resourceType == "movies").slug'
> ["man-faith"]

# Getting `a man of faith` directly by its slug `man-faith`
curl 'https://api.xconfessions.com/api/movies/slug/man-faith' | jq '.data.slug'
> "man-faith"
```

### Broken search: `Private dancer`
```sh
# Trying to search for `private dancer`
curl -X POST'https://api.xconfessions.com/api/search?query=private+dancer'
    | jq 'map(select(.resourceType == "movies").slug'
> []

# Getting `private dancer` directly by its slug `private-dancer`
curl 'https://api.xconfessions.com/api/movies/slug/private-dancer' | jq '.data.slug'
> "private-dancer"
```
