### PR TITLE
FlareSolver FakeResponse Fix

### DIFF
--- a/Contents/Code/PAutils.py
+++ b/Contents/Code/PAutils.py
@@ -48,7 +48,6 @@ def flareSolverrRequest(url, method, **kwargs):
     if req.ok:
         data = req.json()['solution']
         headers = {'User-Agent': data['userAgent']}
-        headers['User-Agent'] = data['userAgent']
         cookies = {cookie['name']: cookie['value'] for cookie in data['cookies']}
 
         return FakeResponse(req, url, data['status'], data['response'], headers, cookies)

--- a/Contents/Code/PAutils.py
+++ b/Contents/Code/PAutils.py
@@ -47,11 +47,11 @@ def flareSolverrRequest(url, method, **kwargs):
     req = HTTPRequest('%s/v1' % Prefs['flaresolverr_endpoint'], headers={'Content-Type': 'application/json'}, params=json.dumps(req_params), timeout=60, bypass=False)
     if req.ok:
         data = req.json()['solution']
-        headers = data['headers']
+        headers = {'User-Agent': data['userAgent']}
         headers['User-Agent'] = data['userAgent']
         cookies = {cookie['name']: cookie['value'] for cookie in data['cookies']}
 
-        return FakeResponse(req, url, int(data['headers']['status']), data['response'], headers, cookies)
+        return FakeResponse(req, url, data['status'], data['response'], headers, cookies)
 
     return None
 


### PR DESCRIPTION
The current FlareSolverr version has a slightly different format for the headers which stopped it from working.

Resolves: https://github.com/PAhelper/PhoenixAdult.bundle/issues/1862