### PR TITLE
KMP/Update KMadison/PFidelity/TFidelity to Handle Results with no Public Tour Page

### DIFF
--- a/Contents/Code/PAsiteList.py
+++ b/Contents/Code/PAsiteList.py
@@ -11,7 +11,7 @@ import networkSteppedUp
 import networkGammaEnt
 import siteJulesJordan
 import networkPerfectGonzo
-import networkPornFidelity
+import networkKellyMadison
 import networkBadoinkVR
 import siteVRBangers
 import networkHighTechVR
@@ -376,9 +376,9 @@ searchSites = {
     181: ('We Live Together', 'https://www.realitykings.com', 'https://site-api.project1service.com'),
     182: ('Wives in Pantyhose', 'https://www.realitykings.com', 'https://site-api.project1service.com'),
     183: ('21Naturals', 'https://www.21naturals.com', 'https://tsmkfa364q-dsn.algolia.net/1/indexes/*/queries'),
-    184: ('PornFidelity', 'https://www.pornfidelity.com', '/episodes/search/?site=2&page=1&search='),
-    185: ('TeenFidelity', 'https://www.pornfidelity.com', '/episodes/search/?site=3&page=1&search='),
-    186: ('Kelly Madison', 'https://www.pornfidelity.com', '/episodes/search/?site=1&page=1&search='),
+    184: ('PornFidelity', 'https://www.pornfidelity.com', '/episodes/search/??site=2&page=1&search='),
+    185: ('TeenFidelity', 'https://www.pornfidelity.com', '/episodes/search/??site=3&page=1&search='),
+    186: ('Kelly Madison', 'https://www.pornfidelity.com', '/episodes/search/??site=1&page=1&search='),
     187: ('TeamSkeet', 'https://www.teamskeet.com', '/movies/'),
     188: ('Exxxtra Small', 'https://www.teamskeet.com', '/movies/'),
     189: ('Teen Pies', 'https://www.teamskeet.com', '/movies/'),
@@ -2314,17 +2314,9 @@ def getProviderFromSiteNum(siteNum):
         elif (137 <= siteNum <= 182) or (822 <= siteNum <= 828) or siteNum == 1593 or siteNum == 1737 or siteNum == 1743:
             provider = network1service
 
-        # PornFidelity
-        elif siteNum == 184:
-            provider = networkPornFidelity
-
-        # TeenFidelity
-        elif siteNum == 185:
-            provider = networkPornFidelity
-
-        # Kelly Madison
-        elif siteNum == 186:
-            provider = networkPornFidelity
+        # Kelly Madison Productions
+        elif (184 <= siteNum <= 186):
+            provider = networkKellyMadison
 
         # TeamSkeet
         elif (187 <= siteNum <= 215) or (566 <= siteNum <= 567) or siteNum == 626 or siteNum == 686 or siteNum == 748 or siteNum == 807 or (845 <= siteNum <= 851) or siteNum == 875 or (997 <= siteNum <= 1011) or (1249 <= siteNum <= 1251) or (1354 <= siteNum <= 1356) or (1362 <= siteNum <= 1363) or (1371 <= siteNum <= 1373) or siteNum == 1390 or (1399 <= siteNum <= 1425) or (1584 <= siteNum <= 1588) or siteNum == 1736:

--- a/Contents/Code/networkKellyMadison.py
+++ b/Contents/Code/networkKellyMadison.py
@@ -24,9 +24,9 @@ def search(results, lang, siteNum, searchData):
         result = PAutils.Encode(HTML.StringFromElement(searchResult))
 
         date = searchResult.xpath('.//span[.//i[@class="far fa-calendar-alt"]]')
-        if date:
+        try:
             releaseDate = datetime.strptime(date[0].text_content().strip(), '%b %d, %Y').strftime('%Y-%m-%d')
-        else:
+        except:
             releaseDate = searchData.dateFormat() if searchData.date else ''
 
         displayDate = releaseDate if date else ''
@@ -65,16 +65,6 @@ def update(metadata, lang, siteNum, movieGenres, movieActors, art):
         # Studio
         metadata.studio = 'Kelly Madison Productions'
 
-        # Tagline and Collection(s)
-        if 'Teenfidelity' in metadata.title:
-            tagline = 'TeenFidelity'
-        elif 'Kelly Madison' in metadata.title:
-            tagline = 'Kelly Madison'
-        else:
-            tagline = 'PornFidelity'
-        metadata.tagline = tagline
-        metadata.collections.add(tagline)
-
         # Actors
         actors = detailsPageElements.xpath('//a[@class="is-underlined"]')
     except:
@@ -84,13 +74,18 @@ def update(metadata, lang, siteNum, movieGenres, movieActors, art):
         # Studio
         metadata.studio = 'Kelly Madison Productions'
 
-        # Tagline and Collection(s)
-        tagline = PAsearchSites.getSearchSiteName(siteNum)
-        metadata.tagline = tagline
-        metadata.collections.add(tagline)
-
         # Actors
         actors = searchResult.xpath('.//a[contains(@href, "/models/")]')
+
+    # Tagline and Collection(s)
+    if 'teenfidelity' in metadata.title.lower():
+        tagline = 'TeenFidelity'
+    elif 'kelly madison' in metadata.title.lower():
+        tagline = 'Kelly Madison'
+    else:
+        tagline = PAsearchSites.getSearchSiteName(siteNum)
+    metadata.tagline = tagline
+    metadata.collections.add(tagline)
 
     # Release Date
     date = detailsPageElements.xpath('//li[.//i[@class="fas fa-calendar"]]')

--- a/Contents/Code/networkPornFidelity.py
+++ b/Contents/Code/networkPornFidelity.py
@@ -3,22 +3,44 @@ import PAutils
 
 
 def search(results, lang, siteNum, searchData):
+    sceneID = None
+    parts = searchData.title.split()
+    if unicode(re.sub(r'^e(?=\d+$)', '', parts[0], flags=re.IGNORECASE), 'UTF-8').isdigit():
+        sceneID = re.sub(r'^e(?=\d+$)', '', parts[0], flags=re.IGNORECASE)
+        searchData.title = searchData.title.replace(parts[0], '', 1).strip()
+
+    searchData.encoded = urllib.quote(searchData.title)
     req = PAutils.HTTPRequest(PAsearchSites.getSearchSearchURL(siteNum) + searchData.encoded, cookies={'nats': 'MC4wLjMuNTguMC4wLjAuMC4w'})
     searchResults = HTML.ElementFromString(req.json()['html'])
     for searchResult in searchResults.xpath('//div[@class="card episode"]'):
         titleNoFormatting = searchResult.xpath('.//a[@class="text-km"] | .//a[@class="text-pf"] | .//a[@class="text-tf"]')[0].text_content().strip()
 
         sceneURL = searchResult.xpath('.//a[@class="text-km"] | .//a[@class="text-pf"] | .//a[@class="text-tf"]')[0].get('href')
+        episodeID = searchResult.xpath('.//span[@class="card-footer-item"]')[-1].text_content().split('#')[-1].strip()
+        searchID = sceneURL.split('/')[-1]
         curID = PAutils.Encode(sceneURL)
 
-        releaseDate = searchData.dateFormat() if searchData.date else ''
+        title = PAutils.Encode(titleNoFormatting)
+        result = PAutils.Encode(HTML.StringFromElement(searchResult))
 
-        if searchData.date:
+        date = searchResult.xpath('.//span[.//i[@class="far fa-calendar-alt"]]')
+        if date:
+            releaseDate = datetime.strptime(date[0].text_content().strip(), '%b %d, %Y').strftime('%Y-%m-%d')
+        else:
+            releaseDate = searchData.dateFormat() if searchData.date else ''
+
+        displayDate = releaseDate if date else ''
+
+        if sceneID and int(sceneID) == int(episodeID):
+            score = 100
+        elif sceneID and int(sceneID) == int(searchID):
+            score = 100
+        elif searchData.date:
             score = 100 - Util.LevenshteinDistance(searchData.date, releaseDate)
         else:
             score = 100 - Util.LevenshteinDistance(searchData.title.lower(), titleNoFormatting.lower())
 
-        results.Append(MetadataSearchResult(id='%s|%d|%s' % (curID, siteNum, releaseDate), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), releaseDate), score=score, lang=lang))
+        results.Append(MetadataSearchResult(id='%s|%d|%s|%s|%s' % (curID, siteNum, releaseDate, title, result), name='%s [%s] %s' % (titleNoFormatting, PAsearchSites.getSearchSiteName(siteNum), displayDate), score=score, lang=lang))
 
     return results
 
@@ -27,30 +49,56 @@ def update(metadata, lang, siteNum, movieGenres, movieActors, art):
     metadata_id = str(metadata.id).split('|')
     sceneURL = PAutils.Decode(metadata_id[0])
     sceneDate = metadata_id[2]
+    if len(metadata_id) > 3:
+        title = PAutils.Decode(metadata_id[3])
+        searchResult = HTML.ElementFromString(PAutils.Decode(metadata_id[4]))
     req = PAutils.HTTPRequest(sceneURL, cookies={'nats': 'MC4wLjMuNTguMC4wLjAuMC4w'})
     detailsPageElements = HTML.ElementFromString(req.text)
 
-    # Title
-    metadata.title = detailsPageElements.xpath('//div[@class="level-left"]')[0].text_content().strip()
+    try:
+        # Title
+        metadata.title = PAutils.parseTitle(detailsPageElements.xpath('//div[@class="level-left"]')[0].text_content().strip(), siteNum)
 
-    # Summary
-    metadata.summary = detailsPageElements.xpath('//div[@class="column is-three-fifths"]')[0].text_content().replace('Episode Summary', '').strip()
+        # Summary
+        metadata.summary = detailsPageElements.xpath('//div[@class="column is-three-fifths"]')[0].text_content().replace('Episode Summary', '').strip()
 
-    # Studio
-    metadata.studio = 'PornFidelity'
+        # Studio
+        metadata.studio = 'Kelly Madison Productions'
 
-    # Tagline and Collection(s)
-    if 'Teenfidelity' in metadata.title:
-        tagline = 'TeenFidelity'
-    elif 'Kelly Madison' in metadata.title:
-        tagline = 'Kelly Madison'
-    else:
-        tagline = 'PornFidelity'
-    metadata.tagline = tagline
-    metadata.collections.add(tagline)
+        # Tagline and Collection(s)
+        if 'Teenfidelity' in metadata.title:
+            tagline = 'TeenFidelity'
+        elif 'Kelly Madison' in metadata.title:
+            tagline = 'Kelly Madison'
+        else:
+            tagline = 'PornFidelity'
+        metadata.tagline = tagline
+        metadata.collections.add(tagline)
+
+        # Actors
+        actors = detailsPageElements.xpath('//a[@class="is-underlined"]')
+    except:
+        # Title
+        metadata.title = PAutils.parseTitle(title, siteNum)
+
+        # Studio
+        metadata.studio = 'Kelly Madison Productions'
+
+        # Tagline and Collection(s)
+        tagline = PAsearchSites.getSearchSiteName(siteNum)
+        metadata.tagline = tagline
+        metadata.collections.add(tagline)
+
+        # Actors
+        actors = searchResult.xpath('.//a[contains(@href, "/models/")]')
 
     # Release Date
-    if sceneDate:
+    date = detailsPageElements.xpath('//li[.//i[@class="fas fa-calendar"]]')
+    if date:
+        date_object = datetime.strptime(date[0].text_content().split(':')[-1].strip(), '%Y-%m-%d')
+        metadata.originally_available_at = date_object
+        metadata.year = metadata.originally_available_at.year
+    elif sceneDate:
         date_object = parse(sceneDate)
         metadata.originally_available_at = date_object
         metadata.year = metadata.originally_available_at.year
@@ -60,7 +108,6 @@ def update(metadata, lang, siteNum, movieGenres, movieActors, art):
     movieGenres.addGenre('Heterosexual')
 
     # Actor(s)
-    actors = detailsPageElements.xpath('//a[@class="is-underlined"]')
     if actors:
         if len(actors) == 3:
             movieGenres.addGenre('Threesome')

--- a/docs/sitelist.md
+++ b/docs/sitelist.md
@@ -705,7 +705,7 @@ If you're having difficulty finding the SceneID, double-check [PAsiteList.py](..
   - Karups Hometown Amateurs
   - Karups Older Women
   - Karups Private Collection
-+ #### Kelly Madison Media | ✅
++ #### Kelly Madison Productions | ✅ - **Episode ID or URL ID** (Date and Summary not always available)
   - Kelly Madison
   - PornFidelity
   - TeenFidelity


### PR DESCRIPTION
 - Adds Date when Available
 - Adds Actors from Search Results if no Public Page
 - Correct Collections to Rely on filename if KM/TF not in title
 - Improve Matches by Supporting URL ID and Episode ID (forms: e###, ###, or ##########)
 - Backwards compatible with previous matches
 - Rename to Kelly Madison Productions to match site