### PR TITLE
N1S/Fix Image Order

### DIFF
--- a/Contents/Code/network1service.py
+++ b/Contents/Code/network1service.py
@@ -161,7 +161,7 @@ def update(metadata, lang, siteNum, movieGenres, movieActors, art):
     # Posters
     for imageType in ['poster', 'cover']:
         if imageType in detailsPageElements['images']:
-            for image in detailsPageElements['images'][imageType]:
+            for image in sorted(detailsPageElements['images'][imageType]):
                 if image.isdigit():
                     art.append(detailsPageElements['images'][imageType][image]['xx']['url'])
 


### PR DESCRIPTION
Fixes #1911

Images are coming from API in the order: 1, 0, 2, 3, 4. Sorting them puts image 0 in front.