### PR TITLE
fix(XConfessions): fallback if poster is None

### DIFF
--- a/Contents/Code/siteXConfessions.py
+++ b/Contents/Code/siteXConfessions.py
@@ -98,7 +98,11 @@ def update(metadata, lang, siteNum, movieGenres, movieActors, art):
     movieActors.addDirector(directorName, '')
 
     # Poster
-    art.append(detailsPageElements['poster_picture'].split('?', 1)[0])
+    if detailsPageElements['poster_picture'] is not None:
+        art.append(detailsPageElements['poster_picture'].split('?', 1)[0])
+    # fallback to mobile banner if no poster
+    elif detailsPageElements['banner_image_mobile'] is not None:
+        art.append(detailsPageElements['banner_image_mobile'].split('?', 1)[0])
 
     for photoLink in detailsPageElements['album']:
         img = photoLink['path'].split('?', 1)[0]


### PR DESCRIPTION
Data response example

```json
{
  "guest_stars": [],
  "poster_picture": null,
  "cover_title_picture": "https:\/\/img.lustcinema.com\/13a590d0-229b-4685-943e-325df91b35cd.jpeg?auto=compress%2Cformat",
  "cover_title_animation": "https:\/\/img.lustcinema.com\/RmVMLoNuH4YRPfLwpdwohilCjUep3JJJXxjPTWjN.gif?auto=compress%2Cformat",
  "info_title_picture": "https:\/\/img.lustcinema.com\/1a4977d1-572c-4243-8b42-c3c759405ebd.png?auto=compress%2Cformat",
  "mobile_detail_picture": "https:\/\/img.lustcinema.com\/V2W5Ge49JJhi7alpvR4JQyjnMbH7jNDqn4LcvOFQ.jpeg?auto=compress%2Cformat",
  "bts_poster_picture": "https:\/\/img.lustcinema.com\/PXaYaLdV6JQbxynMT84MqDafVvzPVSgf7xgRiny4.jpeg?auto=compress%2Cformat",
  "banner_image": "https:\/\/img.lustcinema.com\/OvxKKXsqmH49JTMZJHU5OwqWhDeyRotNezpZOihg.jpeg?auto=compress%2Cformat",
  "banner_image_mobile": "https:\/\/img.lustcinema.com\/6t9qnat5BSnVx9kvnsGPsHNqkHhgcu2CvtMXXdf6.jpeg?auto=compress%2Cformat"
}
```